### PR TITLE
Build from the current source directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,8 +5,8 @@ set(CMAKE_CXX_FLAGS "-Wall")
 set(CMAKE_CXX_FLAGS_RELEASE "-O2")
 set(CMAKE_CXX_STANDARD 11)
 
-include_directories(BEFORE ${CMAKE_SOURCE_DIR})
-include_directories(BEFORE ${CMAKE_SOURCE_DIR}/src)
+include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR})
+include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR}/src)
 
 if (NOT INSTALL_LIB_DIR)
   set(INSTALL_LIB_DIR ${CMAKE_INSTALL_PREFIX}/lib)


### PR DESCRIPTION
This allows paraglob to be made from a parent directory allowing for integration with Zeek's build setup. 

Currently, building paraglob into Zeek is made difficult because the `CMAKE_SOURCE_DIR` is actually a parent directory.  Paraglob still works as expected otherwise.