### PR TITLE
Improve the way internal failures are communicated.

### DIFF
--- a/ahocorasick/AhoCorasickPlus.cpp
+++ b/ahocorasick/AhoCorasickPlus.cpp
@@ -71,13 +71,6 @@ AhoCorasickPlus::EnumReturnStatus AhoCorasickPlus::addPattern
     return rv;
 }
 
-AhoCorasickPlus::EnumReturnStatus AhoCorasickPlus::addPattern
-    (const char pattern[], PatternId id)
-{
-    std::string tmpString = pattern;
-    return addPattern (tmpString, id);
-}
-
 void AhoCorasickPlus::finalize () {
     ac_trie_finalize (m_automata);
 }
@@ -86,7 +79,7 @@ void AhoCorasickPlus::search (const std::string &text, bool keep)
 {
     m_acText->astring = text.c_str();
     m_acText->length = text.size();
-    ac_trie_settext (m_automata, m_acText, (int)keep);
+    ac_trie_settext (m_automata, m_acText, keep);
 }
 
 std::vector<int> AhoCorasickPlus::findAll (const std::string& text, bool keep)
@@ -97,7 +90,7 @@ std::vector<int> AhoCorasickPlus::findAll (const std::string& text, bool keep)
   AC_MATCH_t matchp;
   unsigned int j;
 
-  while ((matchp = ac_trie_findnext (m_automata)).size)
+  while ((matchp = ac_trie_findnext(m_automata)).size)
   {
       for (j = 0; j < matchp.size; j++)
       {
@@ -107,4 +100,9 @@ std::vector<int> AhoCorasickPlus::findAll (const std::string& text, bool keep)
   }
 
   return IDs;
+}
+
+bool AhoCorasickPlus::in_good_standing() const
+{
+  return !this->m_automata->trie_open;
 }

--- a/ahocorasick/AhoCorasickPlus.h
+++ b/ahocorasick/AhoCorasickPlus.h
@@ -63,10 +63,13 @@ public:
     EnumReturnStatus addPattern (const char pattern[], PatternId id);
     void             finalize   ();
 
-    void search   (const std::string &text, bool keep);
     std::vector<int> findAll (const std::string& text, bool keep);
 
+    /* Returns true if the automata is compiled. */
+    bool in_good_standing () const;
+
 private:
+    void search   (const std::string &text, bool keep);
     struct ac_trie      *m_automata;
     struct ac_text      *m_acText;
 };

--- a/src/paraglob.cpp
+++ b/src/paraglob.cpp
@@ -41,6 +41,7 @@ void paraglob::Paraglob::add(const std::string& pattern) {
         std::piecewise_construct, std::forward_as_tuple(meta_word),
         std::forward_as_tuple(meta_word, pattern)
       );
+      ++(this->n_patterns);
     } else if (status == AhoCorasickPlus::RETURNSTATUS_DUPLICATE_PATTERN) {
       this->meta_to_node_map.at(meta_word).add_pattern(pattern);
     } else { // Failed to add

--- a/src/paraglob.h
+++ b/src/paraglob.h
@@ -24,6 +24,8 @@ namespace paraglob {
     std::vector<std::string> meta_words;
     /* Patterns with no meta words, ex: '*' & '?' */
     std::vector<std::string> single_wildcards;
+    /* Is the paraglob well made and problem free? */
+    bool good_standing;
 
     /* Get a vector of the meta words in the pattern. */
     std::vector<std::string> get_meta_words(const std::string& pattern);
@@ -31,24 +33,26 @@ namespace paraglob {
     std::vector<std::string> split_on_brackets(const std::string& in);
 
   public:
-    /* Create an empty paraglob to fill with add and finalize with compile */
-    Paraglob() = default;
+    /* Create an empty paraglob to fill and compile later */
+    Paraglob() : good_standing (true) { }
     /* Initialize a paraglob from a (large) vector of patterns and compile */
     Paraglob(const std::vector<std::string>& patterns);
     /* Initialize and compile a paraglob from a serialized one */
     Paraglob(std::unique_ptr<std::vector<uint8_t>> serialized);
-    /* Add a pattern to the paraglob & return true on success */
-    bool add(const std::string& pattern);
-    /* Compile the paraglob */
+    /* Add a pattern to the paraglob. Mutate good_standing on failure. */
+    void add(const std::string& pattern);
+    /* Compile the paraglob. */
     void compile();
     /* Get a vector of the patterns that match the input string */
     std::vector<std::string> get(const std::string& text);
     /* Get a raw byte representation of the paraglob */
-    std::unique_ptr<std::vector<uint8_t>> serialize() const;
+    std::unique_ptr<std::vector<uint8_t>> serialize();
+    /* Returns true if the paraglob is well constructed and compiled. */
+    bool in_good_standing() const;
     /* Get readable contents of the paraglob for debugging */
     std::string str() const;
     /* Two paraglobs are equal if they contain the same patterns */
-    bool operator==(const Paraglob &other);
+    bool operator==(const Paraglob &other) const;
   };
 
 } // namespace paraglob

--- a/src/paraglob.h
+++ b/src/paraglob.h
@@ -26,6 +26,8 @@ namespace paraglob {
     std::vector<std::string> single_wildcards;
     /* Is the paraglob well made and problem free? */
     bool good_standing;
+    /* Number of patterns in the paraglob. */
+    size_t n_patterns;
 
     /* Get a vector of the meta words in the pattern. */
     std::vector<std::string> get_meta_words(const std::string& pattern);
@@ -34,7 +36,7 @@ namespace paraglob {
 
   public:
     /* Create an empty paraglob to fill and compile later */
-    Paraglob() : good_standing (true) { }
+    Paraglob() : good_standing(true), n_patterns(0) { }
     /* Initialize a paraglob from a (large) vector of patterns and compile */
     Paraglob(const std::vector<std::string>& patterns);
     /* Initialize and compile a paraglob from a serialized one */
@@ -49,6 +51,8 @@ namespace paraglob {
     std::unique_ptr<std::vector<uint8_t>> serialize();
     /* Returns true if the paraglob is well constructed and compiled. */
     bool in_good_standing() const;
+    /* Returns the number of patterns in the paraglob. */
+    size_t size() const { return this->n_patterns; }
     /* Get readable contents of the paraglob for debugging */
     std::string str() const;
     /* Two paraglobs are equal if they contain the same patterns */

--- a/src/paraglob_node.h
+++ b/src/paraglob_node.h
@@ -12,43 +12,44 @@
 
 namespace paraglob {
 
-class ParaglobNode {
-public:
-  ParaglobNode(std::string meta_word, std::string init_pattern)
-    : meta_word(std::move(meta_word)), patterns({ std::move(init_pattern) }) { }
+  class ParaglobNode {
+  public:
+    ParaglobNode(std::string meta_word, std::string init_pattern)
+      : meta_word(std::move(meta_word)), patterns({ std::move(init_pattern) }) { }
 
-  std::string get_meta_word() const {
-    return this->meta_word;
-  }
+    std::string get_meta_word() const {
+      return this->meta_word;
+    }
 
-  bool operator==(const ParaglobNode &other) const {
-    return (this->meta_word == other.get_meta_word());
-  }
+    /* Two nodes are the same if they have the same meta_word. */
+    bool operator==(const ParaglobNode &other) const {
+      return (this->meta_word == other.get_meta_word());
+    }
 
-  void add_pattern(std::string pattern) {
-    this->patterns.push_back(std::move(pattern));
-  }
+    void add_pattern(std::string pattern) {
+      this->patterns.push_back(std::move(pattern));
+    }
 
-  /* Merges this nodes matching patterns into the input vector. */
-  void merge_matches(std::vector<std::string>& target, const std::string& text) {
-    std::copy_if(this->patterns.begin(), this->patterns.end(),
-                 std::back_inserter(target),
-                 [text](const std::string& candidate) {
-                   return (fnmatch(candidate.c_str(), text.c_str(), 0) == 0);
-                 });
-  }
+    /* Merges this nodes matching patterns into the input vector. */
+    void merge_matches
+      (std::vector<std::string>& target, const std::string& text) const {
+      const char* c_text = text.c_str();
+      std::copy_if(this->patterns.begin(), this->patterns.end(),
+                   std::back_inserter(target),
+                   [c_text](const std::string& candidate) {
+                     return (fnmatch(candidate.c_str(), c_text, 0) == 0);
+                   });
+    }
 
-  // Merges this nodes patterns into the input vector
-  // Note: this could be done more efficently with a move iterator if we wanted
-  // this to be destructive.
-  void merge_patterns(std::vector<std::string>& target) {
-    target.insert(target.begin(), this->patterns.begin(), this->patterns.end());
-  }
+    /* Merges this nodes patterns into the input vector */
+    void merge_patterns(std::vector<std::string>& target) const {
+      target.insert(target.begin(), this->patterns.begin(), this->patterns.end());
+    }
 
-private:
-    std::string meta_word;
-    std::vector<std::string> patterns;
-};
+  private:
+      std::string meta_word;
+      std::vector<std::string> patterns;
+  };
 
 } // namespace paraglob
 

--- a/src/paraglob_serializer.cpp
+++ b/src/paraglob_serializer.cpp
@@ -3,23 +3,27 @@
 #include "paraglob_serializer.h"
 
 std::unique_ptr<std::vector<uint8_t>>
-  paraglob::ParaglobSerializer::serialize(const std::vector<std::string>& v) {
-    std::unique_ptr<std::vector<uint8_t>> ret (new std::vector<uint8_t>);
-    add_int(v.size(), *ret);
+  paraglob::ParaglobSerializer::serialize
+    (const std::vector<std::string>& v, bool* good_standing) {
+      std::unique_ptr<std::vector<uint8_t>> ret (new std::vector<uint8_t>);
+      add_int(v.size(), *ret);
 
-    for (const std::string &s: v) {
-      add_int(s.length(), *ret);
-      for (const uint8_t &c : s) {
-        ret->push_back(c);
+      for (const std::string &s: v) {
+        add_int(s.length(), *ret);
+        for (const uint8_t c : s) {
+          ret->push_back(c);
+        }
       }
-    }
+
+    // TODO: How can we check to see if serialization was successful & change
+    // good_standing if not?
 
     return ret;
   }
 
 // ret -> [<n_strings><len_1><str_1>, <len_2><str_2>, ... <len_n><str_n>]
 std::vector<std::string> paraglob::ParaglobSerializer::unserialize
-  (const std::unique_ptr<std::vector<uint8_t>>& vsp) {
+  (const std::unique_ptr<std::vector<uint8_t>>& vsp, bool* good_standing) {
     std::vector<std::string> ret;
     // Serialized empty vector.
     if (vsp->size() == 0) {
@@ -28,13 +32,27 @@ std::vector<std::string> paraglob::ParaglobSerializer::unserialize
 
     std::vector<uint8_t>::iterator vsp_it = vsp->begin();
     uint64_t n_strings = get_int_and_move(vsp_it);
+    if (vsp_it > vsp->end()) { // Equality possible if first number is 0
+      *good_standing = false;
+      return ret;
+    }
     // Reserve space ahead of time rather than resizing in loop.
     ret.reserve(n_strings);
 
+    uint64_t l;
     while (vsp_it < vsp->end()) {
-      uint64_t l = get_int_and_move(vsp_it);
+      l = get_int_and_move(vsp_it);
+      // Calls std::string(begin*, end*)
       ret.emplace_back(vsp_it, vsp_it + l);
       std::advance(vsp_it, l);
+    }
+
+    // If the read was successful we have advanced our iterator exactly to the
+    // end and we have read exactly n_strings strings.
+    if (vsp_it > vsp->end()) {
+      *good_standing = false;
+    } else if (ret.size() != n_strings){ // No need to set to false twice
+      *good_standing = false;
     }
 
     return ret;

--- a/src/paraglob_serializer.h
+++ b/src/paraglob_serializer.h
@@ -17,10 +17,10 @@ namespace paraglob {
        [<n_strings><len_1><str_1>, <len_2><str_2>, ... <len_n><str_n>] */
     // TODO: When Zeek supports C++17 char should be replaced by std::byte.
     static std::unique_ptr<std::vector<uint8_t>> serialize
-      (const std::vector<std::string>  &v);
+      (const std::vector<std::string>  &v, bool* good_standing);
     /* Loads a serialized vector and returns it. */
     static std::vector<std::string> unserialize
-      (const std::unique_ptr<std::vector<uint8_t>> &vsp);
+      (const std::unique_ptr<std::vector<uint8_t>> &vsp, bool* good_standing);
   private:
     /* Divides up and adds a large integer to the input vector. */
     static void add_int (uint64_t a, std::vector<uint8_t> &target);

--- a/testing/.btest.failed.dat
+++ b/testing/.btest.failed.dat
@@ -1,1 +1,0 @@
-driver.time

--- a/testing/.btest.failed.dat
+++ b/testing/.btest.failed.dat
@@ -1,0 +1,1 @@
+driver.time

--- a/tools/benchmark.cpp
+++ b/tools/benchmark.cpp
@@ -43,7 +43,10 @@ double benchmark_n(long num_patterns, long num_queries, long match_prob, bool si
   }
 
   // Create the patterns.
-  std::string patterns[num_patterns];
+  // Use a vector, otherwise will run into limit on call stack
+  // for large number of queries
+  std::vector<std::string> patterns;
+  patterns.reserve(num_patterns);
   char buffer[1024];
   int i, j;
 
@@ -66,13 +69,14 @@ double benchmark_n(long num_patterns, long num_queries, long match_prob, bool si
       }
 
       std::string s(strdup(buffer));
-      patterns[i] = s;
+      patterns.push_back(s);
     }
 
-    // Create the queries.
-
-  std::string queries[num_queries];
-
+  // Create the queries.
+  // Use a vector, otherwise will run into limit on call stack
+  // for large number of queries
+  std::vector<std::string> queries;
+  queries.reserve(num_queries);
   for ( i = 0; i < num_queries; i++ ) {
 
       buffer[0] = '\0';
@@ -95,7 +99,7 @@ double benchmark_n(long num_patterns, long num_queries, long match_prob, bool si
           buffer[rounds] = '\0';
       }
 
-      queries[i] = std::string(strdup(buffer));
+      queries.push_back(std::string(strdup(buffer)));
   }
 
   if (!silent) {
@@ -129,24 +133,4 @@ double benchmark_n(long num_patterns, long num_queries, long match_prob, bool si
   }
 
   return elapsed.count() + build_time.count();
-}
-
-void makeGraphData() {
-  /*
-  prints data to the console for generation of 3d plot
-  of paraglob performance.
-  x axis is number of patterns
-  y axis is number of queries
-  z axis is the time taken to build and run the queries
-  */
-  for(long patterns = 500; patterns <= 10000; patterns += 500) {
-    std::cout << "{ ";
-    for(long queries = 1000; queries <= 20000; queries += 1000) {
-      std::cout << benchmark_n(patterns, queries, 10, true);
-      if (queries != 20000) {
-        std::cout << ", ";
-      }
-    }
-    std::cout << "},\n";
-  }
 }

--- a/tools/driver.cpp
+++ b/tools/driver.cpp
@@ -74,9 +74,14 @@ int main(int argc, char* argv[]) {
 		for (int i = 3 ; i < argc ; i++) {
 			v.push_back(std::string(argv[i]));
 		}
+
 		paraglob::Paraglob p(v);
 		paraglob::Paraglob sp(p.serialize());
-		if (p == sp) {
+
+		std::unique_ptr<std::vector<uint8_t>> a (new std::vector<uint8_t>(5, 3));
+		paraglob::Paraglob bad(std::move(a));
+
+		if (p == sp && p.in_good_standing() && !bad.in_good_standing()) {
 			std::cout << "passed" << std::endl;
 		} else {
 			std::cout << "failed" << std::endl;


### PR DESCRIPTION
This adds a variable called `good_standing` to paraglob which serves as a way for it to keep track of how its doing. Methods inside of paraglob make `good_standing` false to indicate that they encountered an issue.

The biggest place that materializes is in the `unserialize` method where there are a couple checks now to verify that the right number of strings have been read and that there aren't bytes left over in the vector when its done.

I could use some suggestions on how to verify that serialization has completed properly. I'm having some trouble thinking of ways that could fail without throwing an exception. One way I thought about was to compute the size in bytes of the input vector in the beginning and then verify that the returned one was the right size, but I'm not sure if the returns for that are worthwhile. If there are a lot of patterns in the paraglob, passing through the vector to sum up the sizes of them all becomes a little expensive.