### PR TITLE
Communicate internal failures by throwing exceptions.

### DIFF
--- a/src/paraglob.cpp
+++ b/src/paraglob.cpp
@@ -4,7 +4,9 @@
 
 paraglob::Paraglob::Paraglob(const std::vector<std::string>& patterns) {
   for (const std::string& pattern : patterns) {
-    this->add(pattern);
+    if ( !(this->add(pattern)) ) {
+      throw std::runtime_error("Failed to add pattern: " + pattern);
+    }
   }
   this->compile();
 }
@@ -133,23 +135,25 @@ std::unique_ptr<std::vector<uint8_t>> paraglob::Paraglob::serialize() const {
 std::string paraglob::Paraglob::str() const {
   const void * address = static_cast<const void*>(this);
   std::stringstream ss;
-  ss << address;
+
+  ss << "paraglob @ " << address << "\nmeta words: [ ";
   std::string name = ss.str();
 
   std::string out ("paraglob @ " + name + "\n" + "meta words: [ ");
   for (const std::string& meta_word : this->meta_words) {
-    out += meta_word + " ";
+    ss << meta_word << " ";
   }
-  out += "]\n";
+  ss <<"]\n";
 
-  out += "patterns: [ ";
+  ss << "patterns: [ ";
   for (auto it : this->meta_to_node_map) {
-    out += it.second.get_meta_word() + " ";
+    ss << it.second.get_meta_word() + " ";
   }
+  ss << "]\n";
 
-  return (out + "]");
+  return ss.str();
 }
 
-bool paraglob::Paraglob::operator==(const Paraglob &other) {
+bool paraglob::Paraglob::operator==(const Paraglob &other) const {
   return (this->meta_to_node_map == other.meta_to_node_map);
 }

--- a/src/paraglob.cpp
+++ b/src/paraglob.cpp
@@ -5,7 +5,7 @@
 paraglob::Paraglob::Paraglob(const std::vector<std::string>& patterns) {
   for (const std::string& pattern : patterns) {
     if ( !(this->add(pattern)) ) {
-      throw std::runtime_error("Failed to add pattern: " + pattern);
+      throw paraglob::add_error("Failed to add pattern: " + pattern);
     }
   }
   this->compile();

--- a/src/paraglob.h
+++ b/src/paraglob.h
@@ -48,7 +48,7 @@ namespace paraglob {
     /* Get readable contents of the paraglob for debugging */
     std::string str() const;
     /* Two paraglobs are equal if they contain the same patterns */
-    bool operator==(const Paraglob &other);
+    bool operator==(const Paraglob &other) const;
   };
 
 } // namespace paraglob

--- a/src/paraglob_exceptions.h
+++ b/src/paraglob_exceptions.h
@@ -1,0 +1,25 @@
+// See the file "COPYING" in the main distribution directory for copyright.
+// Collection of exceptions thrown by paraglob.
+// These allow more specific error handling when dealing with paraglob.
+#ifndef PARAGLOB_EXCEPTIONS_H
+#define PARAGLOB_EXCEPTIONS_H
+
+#include <stdexcept>
+#include <string>
+
+namespace paraglob {
+  /* Indicates that less data was found than expected. */
+  struct underflow_error : public std::underflow_error {
+    underflow_error(std::string msg) : std::underflow_error(msg) {}
+  };
+  /* Indicates that more data was found than expected. */
+  struct overflow_error : public std::overflow_error {
+    overflow_error(std::string msg) : std::overflow_error(msg) {}
+  };
+  /* Thrown when a paraglob fails to add a pattern. */
+  struct add_error : public std::runtime_error {
+    add_error(std::string msg) : std::runtime_error(msg) {}
+  };
+}
+
+#endif

--- a/src/paraglob_serializer.cpp
+++ b/src/paraglob_serializer.cpp
@@ -27,7 +27,7 @@ std::vector<std::string> paraglob::ParaglobSerializer::unserialize
 
     // If n_strings is zero vsp_it will equal vsp->end
     if (vsp_it > vsp->end()){
-      throw std::underflow_error("Serialization data ended unexpectedly.");
+      throw paraglob::underflow_error("Serialization data ended unexpectedly.");
     }
     // Reserve space ahead of time rather than resizing in loop.
     ret.reserve(n_strings);
@@ -41,11 +41,11 @@ std::vector<std::string> paraglob::ParaglobSerializer::unserialize
     // If the read was successful, we have advanced our iterator exactly to the
     // end, and we have read exactly n_strings.
     if (vsp_it > vsp->end()) {
-      throw std::underflow_error("Serialization data ended unexpectedly.");
+      throw paraglob::underflow_error("Serialization data ended unexpectedly.");
     } else if (ret.size() > n_strings) {
-      throw std::overflow_error("Read more patterns than expected.");
+      throw paraglob::overflow_error("Read more patterns than expected.");
     } else if (ret.size() < n_strings) {
-      throw std::underflow_error("Read fewer patterns than expected.");
+      throw paraglob::underflow_error("Read fewer patterns than expected.");
     }
 
     return ret;

--- a/src/paraglob_serializer.cpp
+++ b/src/paraglob_serializer.cpp
@@ -21,13 +21,14 @@ std::unique_ptr<std::vector<uint8_t>>
 std::vector<std::string> paraglob::ParaglobSerializer::unserialize
   (const std::unique_ptr<std::vector<uint8_t>>& vsp) {
     std::vector<std::string> ret;
-    // Serialized empty vector.
-    if (vsp->size() == 0) {
-      return ret;
-    }
 
     std::vector<uint8_t>::iterator vsp_it = vsp->begin();
     uint64_t n_strings = get_int_and_move(vsp_it);
+
+    // If n_strings is zero vsp_it will equal vsp->end
+    if (vsp_it > vsp->end()){
+      throw std::underflow_error("Serialization data ended unexpectedly.");
+    }
     // Reserve space ahead of time rather than resizing in loop.
     ret.reserve(n_strings);
 
@@ -37,16 +38,26 @@ std::vector<std::string> paraglob::ParaglobSerializer::unserialize
       std::advance(vsp_it, l);
     }
 
+    // If the read was successful, we have advanced our iterator exactly to the
+    // end, and we have read exactly n_strings.
+    if (vsp_it > vsp->end()) {
+      throw std::underflow_error("Serialization data ended unexpectedly.");
+    } else if (ret.size() > n_strings) {
+      throw std::overflow_error("Read more patterns than expected.");
+    } else if (ret.size() < n_strings) {
+      throw std::underflow_error("Read fewer patterns than expected.");
+    }
+
     return ret;
   }
 
-void paraglob::ParaglobSerializer::add_int
+inline void paraglob::ParaglobSerializer::add_int
   (uint64_t a, std::vector<uint8_t> &target) {
     uint8_t* chars = reinterpret_cast<uint8_t*>(&a);
     target.insert(target.end(), chars, chars + sizeof(uint64_t));
 }
 
-uint64_t paraglob::ParaglobSerializer::get_int_and_move
+inline uint64_t paraglob::ParaglobSerializer::get_int_and_move
   (std::vector<uint8_t>::iterator &start) {
     uint64_t ret = static_cast<uint64_t>(*start);
     std::advance(start, sizeof(uint64_t));

--- a/src/paraglob_serializer.h
+++ b/src/paraglob_serializer.h
@@ -6,9 +6,9 @@
 
 #include <vector>
 #include <memory> // std::unique_ptr
-#include <stdexcept>
 
 #include <paraglob.h>
+#include "paraglob_exceptions.h"
 
 namespace paraglob {
 

--- a/src/paraglob_serializer.h
+++ b/src/paraglob_serializer.h
@@ -6,6 +6,7 @@
 
 #include <vector>
 #include <memory> // std::unique_ptr
+#include <stdexcept>
 
 #include <paraglob.h>
 

--- a/testing/.btest.failed.dat
+++ b/testing/.btest.failed.dat
@@ -1,0 +1,2 @@
+driver.str
+driver.time

--- a/tools/driver.cpp
+++ b/tools/driver.cpp
@@ -82,6 +82,14 @@ int main(int argc, char* argv[]) {
 			std::cout << "failed" << std::endl;
 		}
 	}
+	else if (strcmp(argv[1], "-str") == 0) {
+		std::vector<std::string> v;
+		for (int i = 3 ; i < argc ; i++) {
+			v.push_back(std::string(argv[i]));
+		}
+		paraglob::Paraglob p(v);
+		std::cout << p.str();
+	}
 	else {
 		std::cout << "Unrecognized first param\n";
 	}


### PR DESCRIPTION
This is a new take on https://github.com/zeek/paraglob/pull/6 which throws exceptions on failures rather than using a clunky `in_good_standing` function. I thought this was a little more appropriate as a separate pull request because it uses almost none of the same code.

I thought about writing some custom exception classes for paraglob, but ultimately decided against it because it seems like unnecessary complexity to add to the API while `<stdexcept>` already has errors that pretty well encapsulate the ones a paraglob might throw. If anyone disagrees with that though I'm happy to be persuaded.