### PR TITLE
Improve building and testing.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,10 @@
 project(paraglob)
 cmake_minimum_required(VERSION 2.8.12)
 
+include(RequireCXX11.cmake)
+
 set(CMAKE_CXX_FLAGS "-Wall")
 set(CMAKE_CXX_FLAGS_RELEASE "-O2")
-set(CMAKE_CXX_STANDARD 11)
 
 include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR})
 include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR}/src)

--- a/RequireCXX11.cmake
+++ b/RequireCXX11.cmake
@@ -1,0 +1,79 @@
+# Detect if compiler version is sufficient for supporting C++11.
+# If it is, CMAKE_CXX_FLAGS are modified appropriately and HAVE_CXX11
+# is set to a true value.  Else, CMake exits with a fatal error message.
+# This currently only works for GCC and Clang compilers.
+# In Cmake 3.1+, CMAKE_CXX_STANDARD_REQUIRED should be able to replace
+# all the logic below.
+
+# This is a copy from zeek/cmake/RequireCXX11.cmake. Rather than including the
+# entire subdirectory, we thought it would be cleaner to just move this one
+# file over.
+
+if ( DEFINED HAVE_CXX11 )
+    return()
+endif ()
+
+include(CheckCXXSourceCompiles)
+
+set(required_gcc_version 4.8)
+set(required_clang_version 3.3)
+
+macro(cxx11_compile_test)
+    # test a header file that has to be present in C++11
+    check_cxx_source_compiles("
+    #include <array>
+    #include <iostream>
+        int main() {
+            std::array<int, 2> a{ {1, 2} };
+            for (const auto& e: a)
+                std::cout << e << ' ';
+            std::cout << std::endl;
+            }
+        " cxx11_header_works)
+
+    if (NOT cxx11_header_works)
+        message(FATAL_ERROR "C++11 headers cannot be used for compilation")
+    endif ()
+endmacro()
+
+# CMAKE_CXX_COMPILER_VERSION may not always be available (e.g. particularly
+# for CMakes older than 2.8.10, but use it if it exists.
+if ( DEFINED CMAKE_CXX_COMPILER_VERSION )
+    if ( CMAKE_CXX_COMPILER_ID STREQUAL "GNU" )
+        if ( CMAKE_CXX_COMPILER_VERSION VERSION_LESS ${required_gcc_version} )
+            message(FATAL_ERROR "GCC version must be at least "
+                    "${required_gcc_version} for C++11 support, detected: "
+                    "${CMAKE_CXX_COMPILER_VERSION}")
+        endif ()
+    elseif ( CMAKE_CXX_COMPILER_ID STREQUAL "Clang" )
+        if ( CMAKE_CXX_COMPILER_VERSION VERSION_LESS ${required_clang_version} )
+            message(FATAL_ERROR "Clang version must be at least "
+                    "${required_clang_version} for C++11 support, detected: "
+                    "${CMAKE_CXX_COMPILER_VERSION}")
+        endif ()
+    endif ()
+
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+    cxx11_compile_test()
+
+    set(HAVE_CXX11 true)
+    return()
+endif ()
+
+# Need to manually retrieve compiler version.
+if ( CMAKE_CXX_COMPILER_ID STREQUAL "GNU" )
+    execute_process(COMMAND ${CMAKE_CXX_COMPILER} -dumpversion OUTPUT_VARIABLE
+                    gcc_version)
+    if ( ${gcc_version} VERSION_LESS ${required_gcc_version} )
+        message(FATAL_ERROR "GCC version must be at least "
+                "${required_gcc_version} for C++11 support, manually detected: "
+                "${CMAKE_CXX_COMPILER_VERSION}")
+    endif ()
+elseif ( CMAKE_CXX_COMPILER_ID STREQUAL "Clang" )
+    # TODO: don't seem to be any great/easy ways to get a clang version string.
+endif ()
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+cxx11_compile_test()
+
+set(HAVE_CXX11 true)

--- a/src/paraglob.h
+++ b/src/paraglob.h
@@ -28,7 +28,9 @@ namespace paraglob {
     /* Get a vector of the meta words in the pattern. */
     std::vector<std::string> get_meta_words(const std::string& pattern);
     /* Split a string on pairs of square brackets. */
-    std::vector<std::string> split_on_brackets(const std::string& in);
+    std::vector<std::string> split_on_brackets(const std::string& in) const;
+    /* Get a vector of all the patterns in the paraglob */
+    std::vector<std::string> get_patterns() const;
 
   public:
     /* Create an empty paraglob to fill with add and finalize with compile */

--- a/testing/Baseline/driver.basic_matches/out
+++ b/testing/Baseline/driver.basic_matches/out
@@ -1,1 +1,5 @@
 4
+paraglob:
+meta words:  [ d g og ]
+ patterns:  [ * *og d? d?g d[!wl]g ]
+ 

--- a/testing/Baseline/driver.basic_matches/out
+++ b/testing/Baseline/driver.basic_matches/out
@@ -1,5 +1,5 @@
 4
 paraglob:
 meta words:  [ d g og ]
- patterns:  [ * *og d? d?g d[!wl]g ]
+ patterns: [ * *og d? d?g d[!wl]g ]
  

--- a/testing/Baseline/driver.empty_patterns/out
+++ b/testing/Baseline/driver.empty_patterns/out
@@ -1,1 +1,5 @@
 1
+paraglob:
+meta words:  [ cat dog fish horse frog lion ]
+ patterns:  [ * cat dog? ... lion horse frog ]
+ 

--- a/testing/Baseline/driver.empty_patterns/out
+++ b/testing/Baseline/driver.empty_patterns/out
@@ -1,5 +1,5 @@
 1
 paraglob:
 meta words:  [ cat dog fish horse frog lion ]
- patterns:  [ * cat dog? ... lion horse frog ]
+ patterns: [ * cat dog? ... lion horse frog ]
  

--- a/testing/driver/empty_patterns
+++ b/testing/driver/empty_patterns
@@ -1,2 +1,2 @@
-# @TEST-EXEC:	paraglob-test -n dog "*" cat dog? > out
+# @TEST-EXEC:	paraglob-test -n dog "*" cat dog? fish horse frog lion> out
 # @TEST-EXEC:	btest-diff out

--- a/tools/driver.cpp
+++ b/tools/driver.cpp
@@ -69,6 +69,7 @@ int main(int argc, char* argv[]) {
 		}
 		paraglob::Paraglob p(v);
 		std::cout << p.get(std::string(argv[2])).size() << "\n";
+		std::cout << p.str();
 	} else if (strcmp(argv[1], "-s") == 0) {
 		std::vector<std::string> v;
 		for (int i = 3 ; i < argc ; i++) {


### PR DESCRIPTION
Using `set(CMAKE_CXX_STANDARD 11)` inside `CMakeLists.txt` requires that cmake is using version 3.1. This means that for some installations paraglob would fail to build despite C++11 being supported.

This uses the same script as Zeek to require that C++11 is being used and makes some minor improvements to paraglob's testing functions that will catch if paraglob is modifying its contents when it runs get operations.