### PR TITLE
Fixes issue where CMakeLists.txt would override CXX_FLAGS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,16 @@
 project(paraglob)
 cmake_minimum_required(VERSION 2.8.12)
 
-# Modifies CXX_FLAGS && CXX_FLAGS_RELASE 
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Release)
+endif(NOT CMAKE_BUILD_TYPE)
+string(TOUPPER ${CMAKE_BUILD_TYPE} build_affix)
+
+# Modifies CXX_FLAGS && CXX_FLAGS_RELEASE
 include(RequireCXX11.cmake)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
-set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3")
+set(CMAKE_CXX_FLAGS_RELEASE "-O3")
 
 include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR})
 include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR}/src)
@@ -20,8 +25,9 @@ add_subdirectory(tools)
 
 set(summary
     "=================|  Paraglob Config Summary  |==================="
-    "\nCXXFLAGS:        ${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_${BuildType}}"
-    "\n=================================================================")
+    "\nBUILD_TYPE:          ${build_affix}"
+    "\nCXX_FLAGS:           ${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_${build_affix}}"
+    "\n================================================================="
+    )
 
 message("\n" ${summary} "\n")
-file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/config.summary ${summary})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,8 +3,7 @@ cmake_minimum_required(VERSION 2.8.12)
 
 include(RequireCXX11.cmake)
 
-set(CMAKE_CXX_FLAGS "-Wall")
-set(CMAKE_CXX_FLAGS_RELEASE "-O2")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -O3")
 
 include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR})
 include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR}/src)
@@ -16,3 +15,11 @@ endif ()
 add_subdirectory(ahocorasick)
 add_subdirectory(src)
 add_subdirectory(tools)
+
+set(summary
+    "=================|  Paraglob Config Summary  |==================="
+    "\nCXXFLAGS:        ${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_${BuildType}}"
+    "\n=================================================================")
+
+message("\n" ${summary} "\n")
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/config.summary ${summary})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,11 @@
 project(paraglob)
 cmake_minimum_required(VERSION 2.8.12)
 
+# Modifies CXX_FLAGS && CXX_FLAGS_RELASE 
 include(RequireCXX11.cmake)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -O3")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3")
 
 include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR})
 include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR}/src)

--- a/RequireCXX11.cmake
+++ b/RequireCXX11.cmake
@@ -74,6 +74,7 @@ elseif ( CMAKE_CXX_COMPILER_ID STREQUAL "Clang" )
 endif ()
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -std=c++11")
 cxx11_compile_test()
 
 set(HAVE_CXX11 true)

--- a/RequireCXX11.cmake
+++ b/RequireCXX11.cmake
@@ -74,7 +74,6 @@ elseif ( CMAKE_CXX_COMPILER_ID STREQUAL "Clang" )
 endif ()
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -std=c++11")
 cxx11_compile_test()
 
 set(HAVE_CXX11 true)

--- a/configure
+++ b/configure
@@ -53,7 +53,7 @@ prefix=/usr/local
 CMakeCacheEntries=""
 
 append_cache_entry CMAKE_INSTALL_PREFIX               PATH   $prefix
-append_cache_entry CMAKE_BUILD_TYPE                   STRING RelWithDebInfo
+append_cache_entry CMAKE_BUILD_TYPE                   STRING Release
 
 # parse arguments
 while [ $# -ne 0 ]; do

--- a/testing/Baseline/driver.basic_matches/out
+++ b/testing/Baseline/driver.basic_matches/out
@@ -1,5 +1,5 @@
 4
 paraglob:
 meta words:  [ d g og ]
- patterns:  [ * *og d? d?g d[!wl]g ]
+ patterns: [ * *og d? d?g d[!wl]g ]
  

--- a/testing/Baseline/driver.empty_patterns/out
+++ b/testing/Baseline/driver.empty_patterns/out
@@ -1,5 +1,5 @@
 1
 paraglob:
 meta words:  [ cat dog fish horse frog lion ]
- patterns:  [ * cat dog? ... lion horse frog ]
+ patterns: [ * cat dog? ... lion horse frog ]
  


### PR DESCRIPTION
The earlier pull request missed an issue where `set(CMAKE_CXX_FLAGS "-Wall")` would override changes made by `RequireCXX11.cmake`. This fixes that issue and adds a little message like the other Zeek subdirectories to make debugging issues like this easier going forward.