### PR TITLE
Do not set explicit install directory

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,4 +5,4 @@ add_library(paraglob STATIC paraglob.cpp paraglob_serializer.cpp)
 target_link_libraries(paraglob ahocorasick)
 set_target_properties(paraglob PROPERTIES OUTPUT_NAME paraglob)
 
-install(TARGETS paraglob DESTINATION lib)
+install(TARGETS paraglob)


### PR DESCRIPTION
On Unix systems, libparaglob will probably end up in /usr/local/lib by
default anyway.