### PR TITLE
Avoid calling qsort() with null pointer argument

### DIFF
--- a/src/ahocorasick/node.c
+++ b/src/ahocorasick/node.c
@@ -320,6 +320,9 @@ static int node_edge_compare (const void *l, const void *r)
  *****************************************************************************/
 void node_sort_edges (ACT_NODE_t *nod)
 {
+    if ( ! nod->outgoing )
+        return;
+
     qsort ((void *)nod->outgoing, nod->outgoing_size, 
             sizeof(struct act_edge), node_edge_compare);
 }


### PR DESCRIPTION
Likely no ill-effects of doing so since number of elements was always
observed to be zero whenever a null pointer was passed, but qsort() may
technically be annotated with a `nonnull` attribute, so that triggers an
error when using `-fsanitize=nonnull-attribute`.