### PR TITLE
Fix compiler warning about copying loop variable.

### DIFF
--- a/src/paraglob_serializer.cpp
+++ b/src/paraglob_serializer.cpp
@@ -9,7 +9,7 @@ std::unique_ptr<std::vector<uint8_t>>
 
     for (const std::string &s: v) {
       add_int(s.length(), *ret);
-      for (const uint8_t &c : s) {
+      for (uint8_t c : s) { // copy here because of type change
         ret->push_back(c);
       }
     }


### PR DESCRIPTION
This one:

    paraglob_serializer.cpp:12:27: warning: loop variable 'c' has type 'const uint8_t &' (aka 'const unsigned char &') but is initialized with type 'const char' resulting in a copy [-Wrange-loop-analysis]
    paraglob_serializer.cpp:12:12: note: use non-reference type 'uint8_t' (aka 'unsigned char') to keep the copy or type 'const char &' to prevent copying

Making the copy explicit now.