### PR TITLE
Fix a stringop-truncation warning in mpool_strndup()

### DIFF
--- a/src/ahocorasick/mpool.c
+++ b/src/ahocorasick/mpool.c
@@ -171,7 +171,7 @@ void *mpool_strndup (struct mpool *pool, const char *str, size_t n)
 
     if ((ret = mpool_malloc(pool, n+1)))
     {
-        strncpy((char *)ret, str, n);
+        memcpy(ret, str, n);
         ((char *)ret)[n] = '\0';
     }
 


### PR DESCRIPTION
The previous version did not actually have a problem since it explicitly
added a null-terminator after the strncpy(), but as expected by
semantics/docs of mpool_strndup(), no usages seem to depend on the
behavior of strncpy() over a straight memcpy(), so that is more
appropriate and fixes the compiler warning.

Fixes https://github.com/zeek/zeek/issues/1515