### PR TITLE
Coverity and clang-tidy fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15.0 FATAL_ERROR)
 project(paraglob)
 
 include(GNUInstallDirs)
@@ -13,6 +13,7 @@ include(RequireCXX17.cmake)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
 set(CMAKE_CXX_FLAGS_RELEASE "-O3")
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR}/src)

--- a/include/paraglob/node.h
+++ b/include/paraglob/node.h
@@ -18,20 +18,20 @@ public:
     : meta_word(std::move(meta_word)), patterns({ std::move(init_pattern) }) { }
 
   std::string get_meta_word() const {
-    return this->meta_word;
+    return meta_word;
   }
 
   bool operator==(const ParaglobNode &other) const {
-    return (this->meta_word == other.get_meta_word());
+    return meta_word == other.meta_word;
   }
 
   void add_pattern(std::string pattern) {
-    this->patterns.push_back(std::move(pattern));
+    patterns.push_back(std::move(pattern));
   }
 
   /* Merges this nodes matching patterns into the input vector. */
-  void merge_matches(std::vector<std::string>& target, const std::string& text) {
-    std::copy_if(this->patterns.begin(), this->patterns.end(),
+  void merge_matches(std::vector<std::string>& target, const std::string& text) const {
+    std::copy_if(patterns.begin(), patterns.end(),
                  std::back_inserter(target),
                  [text](const std::string& candidate) {
                    return (fnmatch(candidate.c_str(), text.c_str(), 0) == 0);
@@ -41,8 +41,8 @@ public:
   // Merges this nodes patterns into the input vector
   // Note: this could be done more efficently with a move iterator if we wanted
   // this to be destructive.
-  void merge_patterns(std::vector<std::string>& target) {
-    target.insert(target.begin(), this->patterns.begin(), this->patterns.end());
+  void merge_patterns(std::vector<std::string>& target) const {
+    target.insert(target.begin(), patterns.begin(), patterns.end());
   }
 
 private:

--- a/src/paraglob.cpp
+++ b/src/paraglob.cpp
@@ -18,7 +18,7 @@ paraglob::Paraglob::Paraglob(const std::vector<std::string>& patterns)
 }
 
 paraglob::Paraglob::Paraglob(std::unique_ptr<std::vector<uint8_t>> serialized)
-  : Paraglob(paraglob::ParaglobSerializer::unserialize(std::move(serialized))) {}
+  : Paraglob(paraglob::ParaglobSerializer::unserialize(serialized)) {}
 
 paraglob::Paraglob::~Paraglob() = default;
 
@@ -92,7 +92,7 @@ std::vector<std::string> paraglob::Paraglob::get_meta_words(const std::string &p
   std::vector<std::string> meta_words;
 
   // Split the pattern by brackets
-  for (std::string word : split_on_brackets(pattern)) {
+  for (const std::string& word : split_on_brackets(pattern)) {
     // Parse each bracket section
     std::size_t prev = 0, pos;
 

--- a/src/paraglob.cpp
+++ b/src/paraglob.cpp
@@ -116,7 +116,7 @@ std::vector<std::string> paraglob::Paraglob::get_meta_words(const std::string &p
 std::vector<std::string> paraglob::Paraglob::get_patterns() const {
   std::vector<std::string> patterns;
   // Merge in all of the nodes patterns
-  for (auto it : this->meta_to_node_map) {
+  for (const auto& it : this->meta_to_node_map) {
     it.second.merge_patterns(patterns);
   }
   if (this->single_wildcards.size() > 0)


### PR DESCRIPTION
I was fixing recent Coverity findings and decided to run clang-tidy while I was at it. The CMake changes were necessary for clang-tidy to run correctly.