### PR TITLE
Add pre-commit setup based on Zeek's

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,149 @@
+# See the file "COPYING" in the main distribution directory for copyright.
+
+---
+Language:        Cpp
+AccessModifierOffset: -4
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Right
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: true
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      true
+  IndentBraces:    false
+  SplitEmptyFunction: false
+  SplitEmptyRecord: false
+  SplitEmptyNamespace: false
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Custom
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: false
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     120
+CommentPragmas:  'NOLINT'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks: Regroup
+
+# Include categories go like this:
+# 0: reserved, since this automatically is the primary header for any .cc file
+# 1: zeek-config.h
+# 2: any c-style header
+# 3: any c++-style header
+# 4: any header that starts with "zeek/"
+# 5: everything else, which should catch any of the auto-generated code from the
+#    build directory as well
+# 6: third party doctest header
+#
+# Sections 0-1 and 2-3 get grouped together in their respective blocks
+IncludeCategories:
+  - Regex: '^"zeek-config\.h"'
+    Priority: 1
+    SortPriority: 1
+  - Regex: '^"zeek/zeek-config\.h"'
+    Priority: 1
+    SortPriority: 2
+  - Regex: '^<[[:print:]]+\.(h|hh)>'
+    Priority: 2
+    SortPriority: 2
+  - Regex: '^<[[:print:]]+>'
+    Priority: 2
+    SortPriority: 3
+  - Regex: '^"zeek/3rdparty/doctest.h'
+    Priority: 6
+  - Regex: '^"zeek/'
+    Priority: 4
+  - Regex: '.*'
+    Priority: 5
+
+IncludeIsMainRegex: '$'
+IndentCaseLabels: true
+IndentPPDirectives: None
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: '^BEGIN_'
+MacroBlockEnd:   '^END_'
+MaxEmptyLinesToKeep: 2
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 500
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 1000
+PointerAlignment: Left
+ReflowComments:  true
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: false
+SpaceAfterLogicalNot: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpacesInConditionalStatement: true
+Standard:        Cpp11
+StatementMacros:
+  - STANDARD_OPERATOR_1
+TabWidth:        4
+UseTab:          Never
+---
+Language: Json
+...

--- a/.cmake-format.json
+++ b/.cmake-format.json
@@ -1,0 +1,101 @@
+{
+  "parse": {
+    "additional_commands": {
+      "CheckIPProto": {
+        "kwargs": {
+          "_proto": "*"
+        }
+      },
+      "CheckType": {
+        "kwargs": {
+          "_type": "*",
+          "_alt_type": "*",
+          "_var": "*"
+        }
+      },
+      "SetPackageVersion": {
+        "kwargs": {
+          "_version": "*"
+        }
+      },
+      "SetPackageFileName": {
+        "kwargs": {
+          "_version": "*"
+        }
+      },
+      "SetPackageInstallScripts": {
+        "kwargs": {
+          "VERSION": "*"
+        }
+      },
+      "ConfigurePackaging": {
+        "kwargs": {
+          "_version": "*"
+        }
+      },
+      "SetPackageGenerators": {},
+      "SetPackageMetadata": {},
+      "FindRequiredPackage": {
+        "kwargs": {
+          "packageName": "*"
+        }
+      },
+      "InstallClobberImmune": {
+        "kwargs": {
+          "_srcfile": "*",
+          "_dstfile": "*"
+        }
+      },
+      "InstallPackageConfigFile": {
+        "kwargs": {
+          "_srcfile": "*",
+          "_dstdir": "*",
+          "_dstfilename": "*"
+        }
+      },
+      "InstallShellScript": {
+        "kwargs": {
+          "_srcfile": "*",
+          "_dstfile": "*"
+        }
+      },
+      "InstallSymLink": {
+        "kwargs": {
+          "_filepath": "*",
+          "_sympath": "*"
+        }
+      },
+      "spicy_add_analyzer": {
+        "kwargs": {
+          "NAME": "*",
+          "PACKAGE_NAME": "*",
+          "SOURCES": "*",
+          "MODULES": "*"
+        }
+      },
+      "zeek_add_plugin": {
+        "kwargs": {
+          "INCLUDE_DIRS": "*",
+          "DEPENDENCIES": "*",
+          "SOURCES": "*",
+          "BIFS": "*",
+          "PAC": "*"
+        }
+      }
+    }
+  },
+  "format": {
+    "always_wrap": [
+      "spicy_add_analyzer",
+      "zeek_add_plugin"
+    ],
+    "line_width": 100,
+    "tab_size": 4,
+    "separate_ctrl_name_with_space": true,
+    "max_subgroups_hwrap": 3,
+    "line_ending": "unix"
+  },
+  "markup": {
+    "enable_markup": false
+  }
+}

--- a/.license-header.py
+++ b/.license-header.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+
+import re
+import sys
+
+exit_code = 0
+
+copyright_pat = re.compile(
+    r"See the file \"COPYING\" in the main distribution directory for copyright."
+)
+
+
+def match_line(line):
+    m = copyright_pat.search(line)
+    if m is not None:
+        return True
+
+    return False
+
+
+for f in sys.argv[1:]:
+    has_license_header = False
+    with open(f) as fp:
+        for line in fp:
+            line = line.strip()
+            if has_license_header := match_line(line):
+                break
+
+    if not has_license_header:
+        print(f"{f}:does not seem to contain a license header", file=sys.stderr)
+        exit_code = 1
+
+sys.exit(exit_code)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,41 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+#
+repos:
+- repo: local
+  hooks:
+  - id: license
+    name: Check for license headers
+    entry: ./.license-header.py
+    language: python
+    files: '\.(h|c|cpp|cc)$'
+    types: [file]
+    exclude: '^src/ahocorasick/.*'
+
+  - id: btest-command-commented
+    name: Check that all BTest command lines are commented out
+    entry: '^\s*@TEST-'
+    language: pygrep
+    files: '^testing/btest/.*$'
+
+- repo: https://github.com/pre-commit/mirrors-clang-format
+  rev: v20.1.8
+  hooks:
+  - id: clang-format
+    types_or:
+      - "c"
+      - "c++"
+      - "json"
+    exclude: '^src/ahocorasick/.*'
+
+- repo: https://github.com/cheshirekow/cmake-format-precommit
+  rev: v0.6.13
+  hooks:
+  - id: cmake-format
+    exclude: '^src/ahocorasick/.*'
+
+- repo: https://github.com/crate-ci/typos
+  rev: v1.35.3
+  hooks:
+    - id: typos
+      exclude: '^(.typos.toml|src/ahocorasick/.*)$'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,9 +3,9 @@ project(paraglob)
 
 include(GNUInstallDirs)
 
-if(NOT CMAKE_BUILD_TYPE)
+if (NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release)
-endif(NOT CMAKE_BUILD_TYPE)
+endif (NOT CMAKE_BUILD_TYPE)
 string(TOUPPER ${CMAKE_BUILD_TYPE} build_affix)
 
 include(RequireCXXStd.cmake)
@@ -19,18 +19,21 @@ include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR}/src)
 
 add_subdirectory(src)
 
-if ( NOT MSVC )
+if (NOT MSVC)
     # The tools aren't currently supported on windows.
     add_subdirectory(tools)
-endif()
+endif ()
 
-install(DIRECTORY include/paraglob DESTINATION include FILES_MATCHING PATTERN "*.h")
+install(
+    DIRECTORY include/paraglob
+    DESTINATION include
+    FILES_MATCHING
+    PATTERN "*.h")
 
 set(summary
     "=================|  Paraglob Config Summary  |==================="
     "\nBUILD_TYPE:          ${build_affix}"
     "\nCXX_FLAGS:           ${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_${build_affix}}"
-    "\n================================================================="
-    )
+    "\n=================================================================")
 
 message("\n" ${summary} "\n")

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ scripting language. In Zeek, paraglob is implemented as an
 inside Zeek. A paraglob can only be instantiated once from a vector of
 patterns and then only supports get operations which return a vector
 of all patterns matching an input string. These patterns are different than
-the `patttern` type in Zeek in that they are just strings. The syntax is as 
+the `pattern` type in Zeek in that they are just strings. The syntax is as 
 follows:
 
 ```

--- a/RequireCXXStd.cmake
+++ b/RequireCXXStd.cmake
@@ -1,5 +1,5 @@
-# Check for a specific C++ standard level, and require the compiler to
-# support that via some CMake settings.
+# Check for a specific C++ standard level, and require the compiler to support
+# that via some CMake settings.
 
 if (DEFINED ZEEK_CXX_STD)
     return()
@@ -22,9 +22,8 @@ endif ()
 
 include(CheckCXXSourceCompiles)
 
-# The <version> header is a good baseline version of C++20 support for us
-# since we can use it to determine support for various features in other
-# places.
+# The <version> header is a good baseline version of C++20 support for us since
+# we can use it to determine support for various features in other places.
 set(cxx_std_testcode "#include <version>
      int main() { }")
 

--- a/include/paraglob/exceptions.h
+++ b/include/paraglob/exceptions.h
@@ -1,25 +1,25 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 // Collection of exceptions thrown by paraglob.
 // These allow more specific error handling when dealing with paraglob.
-#ifndef PARAGLOB_EXCEPTIONS_H
-#define PARAGLOB_EXCEPTIONS_H
+#pragma once
 
 #include <stdexcept>
-#include <string>
 
 namespace paraglob {
+
 /* Indicates that less data was found than expected. */
 struct underflow_error : public std::underflow_error {
     using std::underflow_error::underflow_error;
 };
+
 /* Indicates that more data was found than expected. */
 struct overflow_error : public std::overflow_error {
     using std::overflow_error::overflow_error;
 };
+
 /* Thrown when a paraglob fails to add a pattern. */
 struct add_error : public std::runtime_error {
     using std::runtime_error::runtime_error;
 };
-} // namespace paraglob
 
-#endif
+} // namespace paraglob

--- a/include/paraglob/exceptions.h
+++ b/include/paraglob/exceptions.h
@@ -8,18 +8,18 @@
 #include <string>
 
 namespace paraglob {
-  /* Indicates that less data was found than expected. */
-  struct underflow_error : public std::underflow_error {
+/* Indicates that less data was found than expected. */
+struct underflow_error : public std::underflow_error {
     using std::underflow_error::underflow_error;
-  };
-  /* Indicates that more data was found than expected. */
-  struct overflow_error : public std::overflow_error {
+};
+/* Indicates that more data was found than expected. */
+struct overflow_error : public std::overflow_error {
     using std::overflow_error::overflow_error;
-  };
-  /* Thrown when a paraglob fails to add a pattern. */
-  struct add_error : public std::runtime_error {
+};
+/* Thrown when a paraglob fails to add a pattern. */
+struct add_error : public std::runtime_error {
     using std::runtime_error::runtime_error;
-  };
-}
+};
+} // namespace paraglob
 
 #endif

--- a/include/paraglob/node.h
+++ b/include/paraglob/node.h
@@ -5,46 +5,39 @@
 #ifndef PARAGLOBNODE_H
 #define PARAGLOBNODE_H
 
-#include <algorithm> // copy_if
 #include <fnmatch.h>
+#include <algorithm> // copy_if
+#include <iterator>
 #include <string>
 #include <vector>
-#include <iterator>
 
 namespace paraglob {
 
 class ParaglobNode {
 public:
-  ParaglobNode(std::string meta_word, std::string init_pattern)
-    : meta_word(std::move(meta_word)), patterns({ std::move(init_pattern) }) { }
+    ParaglobNode(std::string meta_word, std::string init_pattern)
+        : meta_word(std::move(meta_word)), patterns({std::move(init_pattern)}) {}
 
-  std::string get_meta_word() const {
-    return meta_word;
-  }
+    std::string get_meta_word() const { return meta_word; }
 
-  bool operator==(const ParaglobNode &other) const {
-    return meta_word == other.meta_word;
-  }
+    bool operator==(const ParaglobNode& other) const { return meta_word == other.meta_word; }
 
-  void add_pattern(std::string pattern) {
-    patterns.push_back(std::move(pattern));
-  }
+    void add_pattern(std::string pattern) { patterns.push_back(std::move(pattern)); }
 
-  /* Merges this nodes matching patterns into the input vector. */
-  void merge_matches(std::vector<std::string>& target, const std::string& text) const {
-    std::copy_if(patterns.begin(), patterns.end(),
-                 std::back_inserter(target),
-                 [text](const std::string& candidate) {
-                   return (fnmatch(candidate.c_str(), text.c_str(), 0) == 0);
-                 });
-  }
+    /* Merges this nodes matching patterns into the input vector. */
+    void merge_matches(std::vector<std::string>& target, const std::string& text) const {
+        std::copy_if(patterns.begin(), patterns.end(), std::back_inserter(target),
+                     [text](const std::string& candidate) {
+                         return (fnmatch(candidate.c_str(), text.c_str(), 0) == 0);
+                     });
+    }
 
-  // Merges this nodes patterns into the input vector
-  // Note: this could be done more efficently with a move iterator if we wanted
-  // this to be destructive.
-  void merge_patterns(std::vector<std::string>& target) const {
-    target.insert(target.begin(), patterns.begin(), patterns.end());
-  }
+    // Merges this nodes patterns into the input vector
+    // Note: this could be done more efficiently with a move iterator if we wanted
+    // this to be destructive.
+    void merge_patterns(std::vector<std::string>& target) const {
+        target.insert(target.begin(), patterns.begin(), patterns.end());
+    }
 
 private:
     std::string meta_word;

--- a/include/paraglob/node.h
+++ b/include/paraglob/node.h
@@ -2,8 +2,7 @@
 //
 // Node class for paraglob. Holds a meta word and its associated patterns.
 
-#ifndef PARAGLOBNODE_H
-#define PARAGLOBNODE_H
+#pragma once
 
 #include <fnmatch.h>
 #include <algorithm> // copy_if
@@ -45,5 +44,3 @@ private:
 };
 
 } // namespace paraglob
-
-#endif

--- a/include/paraglob/paraglob.h
+++ b/include/paraglob/paraglob.h
@@ -15,41 +15,53 @@ class AhoCorasickPlus;
 namespace paraglob {
 
 class Paraglob {
-private:
-    std::unique_ptr<AhoCorasickPlus> my_ac;
-    std::unordered_map<std::string, paraglob::ParaglobNode> meta_to_node_map;
-    std::vector<std::string> meta_words;
-    /* Patterns with no meta words, ex: '*' & '?' */
-    std::vector<std::string> single_wildcards;
-
-    /* Get a vector of the meta words in the pattern. */
-    std::vector<std::string> get_meta_words(const std::string& pattern);
-    /* Split a string on pairs of square brackets. */
-    std::vector<std::string> split_on_brackets(const std::string& in) const;
-    /* Get a vector of all the patterns in the paraglob */
-    std::vector<std::string> get_patterns() const;
-
 public:
     /* Create an empty paraglob to fill with add and finalize with compile */
     Paraglob();
+
     /* Initialize a paraglob from a (large) vector of patterns and compile */
     Paraglob(const std::vector<std::string>& patterns);
+
     /* Initialize and compile a paraglob from a serialized one */
     Paraglob(std::unique_ptr<std::vector<uint8_t>> serialized);
+
     /* Destructor */
     ~Paraglob();
+
     /* Add a pattern to the paraglob & return true on success */
     bool add(const std::string& pattern);
+
     /* Compile the paraglob */
     void compile();
+
     /* Get a vector of the patterns that match the input string */
     std::vector<std::string> get(const std::string& text);
+
     /* Get a raw byte representation of the paraglob */
     std::unique_ptr<std::vector<uint8_t>> serialize() const;
+
     /* Get readable contents of the paraglob for debugging */
     std::string str() const;
+
     /* Two paraglobs are equal if they contain the same patterns */
     bool operator==(const Paraglob& other) const;
+
+private:
+    /* Get a vector of the meta words in the pattern. */
+    std::vector<std::string> get_meta_words(const std::string& pattern);
+
+    /* Split a string on pairs of square brackets. */
+    std::vector<std::string> split_on_brackets(const std::string& in) const;
+
+    /* Get a vector of all the patterns in the paraglob */
+    std::vector<std::string> get_patterns() const;
+
+    std::unique_ptr<AhoCorasickPlus> my_ac;
+    std::unordered_map<std::string, paraglob::ParaglobNode> meta_to_node_map;
+    std::vector<std::string> meta_words;
+
+    /* Patterns with no meta words, ex: '*' & '?' */
+    std::vector<std::string> single_wildcards;
 };
 
 } // namespace paraglob

--- a/include/paraglob/paraglob.h
+++ b/include/paraglob/paraglob.h
@@ -1,18 +1,14 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#ifndef PARAGLOB_H
-#define PARAGLOB_H
+#pragma once
 
-#include <algorithm> // sort
 #include <cstdint>
-#include <memory>  // std::unique_ptr
-#include <sstream> // str() function
+#include <memory> // std::unique_ptr
 #include <string>
 #include <unordered_map>
 #include <vector>
 
 #include "paraglob/node.h"
-#include "paraglob/serializer.h"
 
 class AhoCorasickPlus;
 
@@ -57,5 +53,3 @@ public:
 };
 
 } // namespace paraglob
-
-#endif

--- a/include/paraglob/paraglob.h
+++ b/include/paraglob/paraglob.h
@@ -3,24 +3,23 @@
 #ifndef PARAGLOB_H
 #define PARAGLOB_H
 
-#include "paraglob/node.h"
-#include "paraglob/serializer.h"
-
 #include <algorithm> // sort
-#include <string>
+#include <cstdint>
+#include <memory>  // std::unique_ptr
 #include <sstream> // str() function
+#include <string>
 #include <unordered_map>
 #include <vector>
-#include <memory> // std::unique_ptr
 
-#include <cstdint>
+#include "paraglob/node.h"
+#include "paraglob/serializer.h"
 
 class AhoCorasickPlus;
 
 namespace paraglob {
 
-  class Paraglob {
-  private:
+class Paraglob {
+private:
     std::unique_ptr<AhoCorasickPlus> my_ac;
     std::unordered_map<std::string, paraglob::ParaglobNode> meta_to_node_map;
     std::vector<std::string> meta_words;
@@ -34,7 +33,7 @@ namespace paraglob {
     /* Get a vector of all the patterns in the paraglob */
     std::vector<std::string> get_patterns() const;
 
-  public:
+public:
     /* Create an empty paraglob to fill with add and finalize with compile */
     Paraglob();
     /* Initialize a paraglob from a (large) vector of patterns and compile */
@@ -54,8 +53,8 @@ namespace paraglob {
     /* Get readable contents of the paraglob for debugging */
     std::string str() const;
     /* Two paraglobs are equal if they contain the same patterns */
-    bool operator==(const Paraglob &other) const;
-  };
+    bool operator==(const Paraglob& other) const;
+};
 
 } // namespace paraglob
 

--- a/include/paraglob/serializer.h
+++ b/include/paraglob/serializer.h
@@ -1,15 +1,11 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 // Class for performing serialization and deserialization of paraglob.
 
-#ifndef PARAGLOB_SERIALIZER_H
-#define PARAGLOB_SERIALIZER_H
+#pragma once
 
 #include <cstdint>
 #include <memory> // std::unique_ptr
 #include <vector>
-
-#include "paraglob/exceptions.h"
-#include "paraglob/paraglob.h"
 
 namespace paraglob {
 
@@ -30,5 +26,3 @@ private:
 };
 
 } // namespace paraglob
-
-#endif

--- a/include/paraglob/serializer.h
+++ b/include/paraglob/serializer.h
@@ -5,6 +5,7 @@
 
 #include <cstdint>
 #include <memory> // std::unique_ptr
+#include <string>
 #include <vector>
 
 namespace paraglob {
@@ -15,12 +16,14 @@ public:
        [<n_strings><len_1><str_1>, <len_2><str_2>, ... <len_n><str_n>] */
     // TODO: When Zeek supports C++17 char should be replaced by std::byte.
     static std::unique_ptr<std::vector<uint8_t>> serialize(const std::vector<std::string>& v);
+
     /* Loads a serialized vector and returns it. */
     static std::vector<std::string> unserialize(const std::unique_ptr<std::vector<uint8_t>>& vsp);
 
 private:
     /* Divides up and adds a large integer to the input vector. */
     static void add_int(uint64_t a, std::vector<uint8_t>& target);
+
     /* Gets the large integer beginning at the iterator and moves it forward. */
     static uint64_t get_int_and_move(std::vector<uint8_t>::iterator& start);
 };

--- a/include/paraglob/serializer.h
+++ b/include/paraglob/serializer.h
@@ -4,31 +4,30 @@
 #ifndef PARAGLOB_SERIALIZER_H
 #define PARAGLOB_SERIALIZER_H
 
-#include <vector>
-#include <memory> // std::unique_ptr
 #include <cstdint>
+#include <memory> // std::unique_ptr
+#include <vector>
 
-#include "paraglob/paraglob.h"
 #include "paraglob/exceptions.h"
+#include "paraglob/paraglob.h"
 
 namespace paraglob {
 
-  class ParaglobSerializer {
-  public:
+class ParaglobSerializer {
+public:
     /* Returns serialized version of vector in form:
        [<n_strings><len_1><str_1>, <len_2><str_2>, ... <len_n><str_n>] */
     // TODO: When Zeek supports C++17 char should be replaced by std::byte.
-    static std::unique_ptr<std::vector<uint8_t>> serialize
-      (const std::vector<std::string>  &v);
+    static std::unique_ptr<std::vector<uint8_t>> serialize(const std::vector<std::string>& v);
     /* Loads a serialized vector and returns it. */
-    static std::vector<std::string> unserialize
-      (const std::unique_ptr<std::vector<uint8_t>> &vsp);
-  private:
+    static std::vector<std::string> unserialize(const std::unique_ptr<std::vector<uint8_t>>& vsp);
+
+private:
     /* Divides up and adds a large integer to the input vector. */
-    static void add_int (uint64_t a, std::vector<uint8_t> &target);
+    static void add_int(uint64_t a, std::vector<uint8_t>& target);
     /* Gets the large integer beginning at the iterator and moves it forward. */
-    static uint64_t get_int_and_move (std::vector<uint8_t>::iterator &start);
-  };
+    static uint64_t get_int_and_move(std::vector<uint8_t>::iterator& start);
+};
 
 } // namespace paraglob
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,19 +1,9 @@
-
-set(AHOCORASICK_SRCS
-  ahocorasick/ahocorasick.c
-  ahocorasick/node.c
-  ahocorasick/mpool.c
-  ahocorasick/replace.c
-  ahocorasick/AhoCorasickPlus.cpp
-)
+set(AHOCORASICK_SRCS ahocorasick/ahocorasick.c ahocorasick/node.c ahocorasick/mpool.c
+                     ahocorasick/replace.c ahocorasick/AhoCorasickPlus.cpp)
 
 add_subdirectory(ahocorasick)
 
-add_library(paraglob STATIC
-  paraglob.cpp
-  paraglob_serializer.cpp
-  ${AHOCORASICK_SRCS}
-)
+add_library(paraglob STATIC paraglob.cpp paraglob_serializer.cpp ${AHOCORASICK_SRCS})
 set_target_properties(paraglob PROPERTIES OUTPUT_NAME paraglob)
 
 install(TARGETS paraglob DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/src/paraglob.cpp
+++ b/src/paraglob.cpp
@@ -2,133 +2,130 @@
 
 #include "paraglob/paraglob.h"
 
-#include "ahocorasick/AhoCorasickPlus.h"
-
 #include <cstdint>
 
-paraglob::Paraglob::Paraglob()
-  : my_ac(new AhoCorasickPlus) {}
+#include "ahocorasick/AhoCorasickPlus.h"
 
-paraglob::Paraglob::Paraglob(const std::vector<std::string>& patterns)
-  : my_ac(new AhoCorasickPlus) {
-  for (const std::string& pattern : patterns) {
-    if ( !(this->add(pattern)) ) {
-      throw paraglob::add_error("Failed to add pattern: " + pattern);
+paraglob::Paraglob::Paraglob() : my_ac(new AhoCorasickPlus) {}
+
+paraglob::Paraglob::Paraglob(const std::vector<std::string>& patterns) : my_ac(new AhoCorasickPlus) {
+    for ( const std::string& pattern : patterns ) {
+        if ( ! (this->add(pattern)) ) {
+            throw paraglob::add_error("Failed to add pattern: " + pattern);
+        }
     }
-  }
-  this->compile();
+    this->compile();
 }
 
 paraglob::Paraglob::Paraglob(std::unique_ptr<std::vector<uint8_t>> serialized)
-  : Paraglob(paraglob::ParaglobSerializer::unserialize(serialized)) {}
+    : Paraglob(paraglob::ParaglobSerializer::unserialize(serialized)) {}
 
 paraglob::Paraglob::~Paraglob() = default;
 
 bool paraglob::Paraglob::add(const std::string& pattern) {
-  AhoCorasickPlus::EnumReturnStatus status;
+    AhoCorasickPlus::EnumReturnStatus status;
 
-  for (const std::string& meta_word : this->get_meta_words(pattern)) {
-    AhoCorasickPlus::PatternId patId = this->meta_words.size();
-    status = this->my_ac->addPattern(meta_word, patId, true);
+    for ( const std::string& meta_word : this->get_meta_words(pattern) ) {
+        AhoCorasickPlus::PatternId patId = this->meta_words.size();
+        status = this->my_ac->addPattern(meta_word, patId, true);
 
-    if (status == AhoCorasickPlus::RETURNSTATUS_SUCCESS) {
-      this->meta_words.push_back(meta_word);
-      // Build the new paraglobNode in place.
-      this->meta_to_node_map.emplace(
-        std::piecewise_construct, std::forward_as_tuple(meta_word),
-        std::forward_as_tuple(meta_word, pattern)
-      );
-    } else if (status == AhoCorasickPlus::RETURNSTATUS_DUPLICATE_PATTERN) {
-      this->meta_to_node_map.at(meta_word).add_pattern(pattern);
-    } else { // Failed to add
-      return false;
+        if ( status == AhoCorasickPlus::RETURNSTATUS_SUCCESS ) {
+            this->meta_words.push_back(meta_word);
+            // Build the new paraglobNode in place.
+            this->meta_to_node_map.emplace(std::piecewise_construct, std::forward_as_tuple(meta_word),
+                                           std::forward_as_tuple(meta_word, pattern));
+        }
+        else if ( status == AhoCorasickPlus::RETURNSTATUS_DUPLICATE_PATTERN ) {
+            this->meta_to_node_map.at(meta_word).add_pattern(pattern);
+        }
+        else { // Failed to add
+            return false;
+        }
     }
-  }
 
-  return true;
+    return true;
 }
 
-void paraglob::Paraglob::compile() {
-  this->my_ac->finalize();
-}
+void paraglob::Paraglob::compile() { this->my_ac->finalize(); }
 
 std::vector<std::string> paraglob::Paraglob::get(const std::string& text) {
-  // Narrow to the meta-word matches
-  std::vector<std::string> patterns;
-  for (int id : this->my_ac->findAll(text, false))
-    this->meta_to_node_map.at(this->meta_words.at(id)).merge_matches(patterns, text);
+    // Narrow to the meta-word matches
+    std::vector<std::string> patterns;
+    for ( int id : this->my_ac->findAll(text, false) )
+        this->meta_to_node_map.at(this->meta_words.at(id)).merge_matches(patterns, text);
 
-  // Single wildcards always need to be checked
-  if (this->single_wildcards.size() > 0)
-    patterns.insert(patterns.end(), this->single_wildcards.begin(), this->single_wildcards.end());
+    // Single wildcards always need to be checked
+    if ( this->single_wildcards.size() > 0 )
+        patterns.insert(patterns.end(), this->single_wildcards.begin(), this->single_wildcards.end());
 
-  // Remove duplicates
-  std::sort(patterns.begin(), patterns.end());
-  patterns.erase(unique(patterns.begin(), patterns.end()), patterns.end());
-  return patterns;
+    // Remove duplicates
+    std::sort(patterns.begin(), patterns.end());
+    patterns.erase(unique(patterns.begin(), patterns.end()), patterns.end());
+    return patterns;
 }
 
-std::vector<std::string> paraglob::Paraglob::split_on_brackets(const std::string &in) const {
-  std::vector<std::string> out;
-  size_t pos;
-  size_t prev = 0;
+std::vector<std::string> paraglob::Paraglob::split_on_brackets(const std::string& in) const {
+    std::vector<std::string> out;
+    size_t pos;
+    size_t prev = 0;
 
-  while ((pos = in.find_first_of('[', prev)) != std::string::npos) {
-    size_t end_bracket = in.find_first_of(']', pos);
-    if (end_bracket != std::string::npos) {
-      out.push_back(in.substr(prev, pos-prev));
-      prev = end_bracket + 1;
-    } else {
-      break;
+    while ( (pos = in.find_first_of('[', prev)) != std::string::npos ) {
+        size_t end_bracket = in.find_first_of(']', pos);
+        if ( end_bracket != std::string::npos ) {
+            out.push_back(in.substr(prev, pos - prev));
+            prev = end_bracket + 1;
+        }
+        else {
+            break;
+        }
     }
-  }
 
-  // There are no more opening / closing brackets
-  // Append the rest of the string
-  out.push_back(in.substr(prev, in.length()-prev));
-  return out;
+    // There are no more opening / closing brackets
+    // Append the rest of the string
+    out.push_back(in.substr(prev, in.length() - prev));
+    return out;
 }
 
 
-std::vector<std::string> paraglob::Paraglob::get_meta_words(const std::string &pattern) {
-  std::vector<std::string> meta_words;
+std::vector<std::string> paraglob::Paraglob::get_meta_words(const std::string& pattern) {
+    std::vector<std::string> meta_words;
 
-  // Split the pattern by brackets
-  for (const std::string& word : split_on_brackets(pattern)) {
-    // Parse each bracket section
-    std::size_t prev = 0, pos;
+    // Split the pattern by brackets
+    for ( const std::string& word : split_on_brackets(pattern) ) {
+        // Parse each bracket section
+        std::size_t prev = 0, pos;
 
-    while ((pos = word.find_first_of("*?", prev)) != std::string::npos) {
-      if (pos > prev) {
-        meta_words.push_back(word.substr(prev, pos-prev));
-      }
-      prev = pos+1;
+        while ( (pos = word.find_first_of("*?", prev)) != std::string::npos ) {
+            if ( pos > prev ) {
+                meta_words.push_back(word.substr(prev, pos - prev));
+            }
+            prev = pos + 1;
+        }
+        if ( prev < word.length() ) {
+            meta_words.push_back(word.substr(prev, std::string::npos));
+        }
     }
-    if (prev < word.length()) {
-      meta_words.push_back(word.substr(prev, std::string::npos));
-    }
-  }
 
-  if (meta_words.size() == 0 && pattern != "") {
-    this->single_wildcards.push_back(pattern);
-  }
-  return meta_words;
+    if ( meta_words.size() == 0 && pattern != "" ) {
+        this->single_wildcards.push_back(pattern);
+    }
+    return meta_words;
 }
 
 std::vector<std::string> paraglob::Paraglob::get_patterns() const {
-  std::vector<std::string> patterns;
-  // Merge in all of the nodes patterns
-  for (const auto& it : this->meta_to_node_map) {
-    it.second.merge_patterns(patterns);
-  }
-  if (this->single_wildcards.size() > 0)
-    patterns.insert(patterns.end(), this->single_wildcards.begin(), this->single_wildcards.end());
+    std::vector<std::string> patterns;
+    // Merge in all of the nodes patterns
+    for ( const auto& it : this->meta_to_node_map ) {
+        it.second.merge_patterns(patterns);
+    }
+    if ( this->single_wildcards.size() > 0 )
+        patterns.insert(patterns.end(), this->single_wildcards.begin(), this->single_wildcards.end());
 
-  // Remove the duplicate patterns. Duplicates don't effect the state.
-  std::sort(patterns.begin(), patterns.end());
-  patterns.erase(unique(patterns.begin(), patterns.end()), patterns.end());
+    // Remove the duplicate patterns. Duplicates don't effect the state.
+    std::sort(patterns.begin(), patterns.end());
+    patterns.erase(unique(patterns.begin(), patterns.end()), patterns.end());
 
-  return patterns;
+    return patterns;
 }
 
 // Returns a string representation of the paraglob that it can rebuild
@@ -143,34 +140,35 @@ std::vector<std::string> paraglob::Paraglob::get_patterns() const {
 // functionality, right now we're choosing not to do this. Instead, paraglob
 // serializes its vector of patterns, and rebuilds itself when unserialized.
 std::unique_ptr<std::vector<uint8_t>> paraglob::Paraglob::serialize() const {
-  return paraglob::ParaglobSerializer::serialize(this->get_patterns());
+    return paraglob::ParaglobSerializer::serialize(this->get_patterns());
 }
 
 std::string paraglob::Paraglob::str() const {
-  std::stringstream ss;
+    std::stringstream ss;
 
-  auto add_string = [&ss](const std::string& p){ ss << p << " "; };
-  auto pretty_add = [add_string](const std::vector<std::string>& v) {
-    add_string("[");
-    if (v.size() > 6) {
-      std::for_each(v.begin(), v.begin() + 3, add_string);
-      add_string("...");
-      std::for_each(v.rbegin(), v.rbegin() + 3, add_string);
-    } else {
-      std::for_each(v.begin(), v.end(), add_string);
-    }
-    add_string("]\n");
-  };
+    auto add_string = [&ss](const std::string& p) { ss << p << " "; };
+    auto pretty_add = [add_string](const std::vector<std::string>& v) {
+        add_string("[");
+        if ( v.size() > 6 ) {
+            std::for_each(v.begin(), v.begin() + 3, add_string);
+            add_string("...");
+            std::for_each(v.rbegin(), v.rbegin() + 3, add_string);
+        }
+        else {
+            std::for_each(v.begin(), v.end(), add_string);
+        }
+        add_string("]\n");
+    };
 
-  add_string("paraglob:\nmeta words: ");
+    add_string("paraglob:\nmeta words: ");
 
-  pretty_add(this->meta_words);
-  add_string("patterns:");
-  pretty_add(this->get_patterns());
+    pretty_add(this->meta_words);
+    add_string("patterns:");
+    pretty_add(this->get_patterns());
 
-  return ss.str();
+    return ss.str();
 }
 
-bool paraglob::Paraglob::operator==(const Paraglob &other) const {
-  return (this->meta_to_node_map == other.meta_to_node_map);
+bool paraglob::Paraglob::operator==(const Paraglob& other) const {
+    return (this->meta_to_node_map == other.meta_to_node_map);
 }

--- a/src/paraglob_serializer.cpp
+++ b/src/paraglob_serializer.cpp
@@ -1,8 +1,11 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
+#include "paraglob/exceptions.h"
 #include "paraglob/serializer.h"
 
-std::unique_ptr<std::vector<uint8_t>> paraglob::ParaglobSerializer::serialize(const std::vector<std::string>& v) {
+using namespace paraglob;
+
+std::unique_ptr<std::vector<uint8_t>> ParaglobSerializer::serialize(const std::vector<std::string>& v) {
     std::unique_ptr<std::vector<uint8_t>> ret(new std::vector<uint8_t>);
     add_int(v.size(), *ret);
 
@@ -17,7 +20,7 @@ std::unique_ptr<std::vector<uint8_t>> paraglob::ParaglobSerializer::serialize(co
 }
 
 // ret -> [<n_strings><len_1><str_1>, <len_2><str_2>, ... <len_n><str_n>]
-std::vector<std::string> paraglob::ParaglobSerializer::unserialize(const std::unique_ptr<std::vector<uint8_t>>& vsp) {
+std::vector<std::string> ParaglobSerializer::unserialize(const std::unique_ptr<std::vector<uint8_t>>& vsp) {
     std::vector<std::string> ret;
 
     std::vector<uint8_t>::iterator vsp_it = vsp->begin();
@@ -51,12 +54,12 @@ std::vector<std::string> paraglob::ParaglobSerializer::unserialize(const std::un
     return ret;
 }
 
-inline void paraglob::ParaglobSerializer::add_int(uint64_t a, std::vector<uint8_t>& target) {
+inline void ParaglobSerializer::add_int(uint64_t a, std::vector<uint8_t>& target) {
     uint8_t* chars = reinterpret_cast<uint8_t*>(&a);
     target.insert(target.end(), chars, chars + sizeof(uint64_t));
 }
 
-inline uint64_t paraglob::ParaglobSerializer::get_int_and_move(std::vector<uint8_t>::iterator& start) {
+inline uint64_t ParaglobSerializer::get_int_and_move(std::vector<uint8_t>::iterator& start) {
     uint64_t ret = static_cast<uint64_t>(*start);
     std::advance(start, sizeof(uint64_t));
     return ret;

--- a/src/paraglob_serializer.cpp
+++ b/src/paraglob_serializer.cpp
@@ -2,63 +2,61 @@
 
 #include "paraglob/serializer.h"
 
-std::unique_ptr<std::vector<uint8_t>>
-  paraglob::ParaglobSerializer::serialize(const std::vector<std::string>& v) {
-    std::unique_ptr<std::vector<uint8_t>> ret (new std::vector<uint8_t>);
+std::unique_ptr<std::vector<uint8_t>> paraglob::ParaglobSerializer::serialize(const std::vector<std::string>& v) {
+    std::unique_ptr<std::vector<uint8_t>> ret(new std::vector<uint8_t>);
     add_int(v.size(), *ret);
 
-    for (const std::string &s: v) {
-      add_int(s.length(), *ret);
-      for (uint8_t c : s) { // copy here because of type change
-        ret->push_back(c);
-      }
+    for ( const std::string& s : v ) {
+        add_int(s.length(), *ret);
+        for ( uint8_t c : s ) { // copy here because of type change
+            ret->push_back(c);
+        }
     }
 
     return ret;
-  }
+}
 
 // ret -> [<n_strings><len_1><str_1>, <len_2><str_2>, ... <len_n><str_n>]
-std::vector<std::string> paraglob::ParaglobSerializer::unserialize
-  (const std::unique_ptr<std::vector<uint8_t>>& vsp) {
+std::vector<std::string> paraglob::ParaglobSerializer::unserialize(const std::unique_ptr<std::vector<uint8_t>>& vsp) {
     std::vector<std::string> ret;
 
     std::vector<uint8_t>::iterator vsp_it = vsp->begin();
     uint64_t n_strings = get_int_and_move(vsp_it);
 
     // If n_strings is zero vsp_it will equal vsp->end
-    if (vsp_it > vsp->end()){
-      throw paraglob::underflow_error("Serialization data ended unexpectedly.");
+    if ( vsp_it > vsp->end() ) {
+        throw paraglob::underflow_error("Serialization data ended unexpectedly.");
     }
     // Reserve space ahead of time rather than resizing in loop.
     ret.reserve(n_strings);
 
-    while (vsp_it < vsp->end()) {
-      uint64_t l = get_int_and_move(vsp_it);
-      ret.emplace_back(vsp_it, vsp_it + l);
-      std::advance(vsp_it, l);
+    while ( vsp_it < vsp->end() ) {
+        uint64_t l = get_int_and_move(vsp_it);
+        ret.emplace_back(vsp_it, vsp_it + l);
+        std::advance(vsp_it, l);
     }
 
     // If the read was successful, we have advanced our iterator exactly to the
     // end, and we have read exactly n_strings.
-    if (vsp_it > vsp->end()) {
-      throw paraglob::underflow_error("Serialization data ended unexpectedly.");
-    } else if (ret.size() > n_strings) {
-      throw paraglob::overflow_error("Read more patterns than expected.");
-    } else if (ret.size() < n_strings) {
-      throw paraglob::underflow_error("Read fewer patterns than expected.");
+    if ( vsp_it > vsp->end() ) {
+        throw paraglob::underflow_error("Serialization data ended unexpectedly.");
+    }
+    else if ( ret.size() > n_strings ) {
+        throw paraglob::overflow_error("Read more patterns than expected.");
+    }
+    else if ( ret.size() < n_strings ) {
+        throw paraglob::underflow_error("Read fewer patterns than expected.");
     }
 
     return ret;
-  }
+}
 
-inline void paraglob::ParaglobSerializer::add_int
-  (uint64_t a, std::vector<uint8_t> &target) {
+inline void paraglob::ParaglobSerializer::add_int(uint64_t a, std::vector<uint8_t>& target) {
     uint8_t* chars = reinterpret_cast<uint8_t*>(&a);
     target.insert(target.end(), chars, chars + sizeof(uint64_t));
 }
 
-inline uint64_t paraglob::ParaglobSerializer::get_int_and_move
-  (std::vector<uint8_t>::iterator &start) {
+inline uint64_t paraglob::ParaglobSerializer::get_int_and_move(std::vector<uint8_t>::iterator& start) {
     uint64_t ret = static_cast<uint64_t>(*start);
     std::advance(start, sizeof(uint64_t));
     return ret;

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,4 +1,3 @@
-
 set(SOURCES driver.cpp benchmark.cpp)
 add_executable(paraglob-test ${SOURCES})
 

--- a/tools/benchmark.cpp
+++ b/tools/benchmark.cpp
@@ -1,29 +1,26 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
 #include "benchmark.h"
-#include <random>
+
 #include <memory>
+#include <random>
 
 std::random_device dev;
 std::mt19937 rng(dev());
-std::uniform_int_distribution<std::mt19937::result_type> dist(0,RAND_MAX);
+std::uniform_int_distribution<std::mt19937::result_type> dist(0, RAND_MAX);
 
-int rand_int()
-  {
-  return dist(rng);
-  }
+int rand_int() { return dist(rng); }
 
 static const char* benchmark_pattern_words[] = {
-    "aaaaaa", "bb", "cccccccccccccccc", "ddddd", "eeeeeeeee", "fffffffffffff", "gggg"
+    "aaaaaa", "bb", "cccccccccccccccc", "ddddd", "eeeeeeeee", "fffffffffffff", "gggg",
 };
 
-const char* random_pattern_word(){
+const char* random_pattern_word() {
     int idx = rand_int() % (sizeof(benchmark_pattern_words) / sizeof(const char*));
     return benchmark_pattern_words[idx];
 }
 
-const char* random_word()
-{
+const char* random_word() {
     static char buffer[1024];
 
     int j;
@@ -38,127 +35,124 @@ const char* random_word()
 }
 
 double benchmark(char* a, char* b, char* c, bool silent) {
-  long num_patterns = atol(a);
-  long num_queries = atol(b);
-  long match_prob = atol(c);
-  return benchmark_n(num_patterns, num_queries, match_prob, silent);
+    long num_patterns = atol(a);
+    long num_queries = atol(b);
+    long match_prob = atol(c);
+    return benchmark_n(num_patterns, num_queries, match_prob, silent);
 }
 
 double benchmark_n(long num_patterns, long num_queries, long match_prob, bool silent) {
-  if (!silent) {
-    std::cout << "creating workload:\n";
-    std::cout << "\t# patterns: " << num_patterns << "\n";
-    std::cout << "\t# queries: " << num_queries << "\n";
-    std::cout << "\t% matches: " << match_prob << "\n";
-  }
+    if ( ! silent ) {
+        std::cout << "creating workload:\n";
+        std::cout << "\t# patterns: " << num_patterns << "\n";
+        std::cout << "\t# queries: " << num_queries << "\n";
+        std::cout << "\t% matches: " << match_prob << "\n";
+    }
 
-  // Create the patterns.
-  std::unique_ptr<std::string[]> patterns(new std::string[num_patterns]);
-  char buffer[1024];
-  int i, j;
+    // Create the patterns.
+    std::unique_ptr<std::string[]> patterns(new std::string[num_patterns]);
+    char buffer[1024];
+    int i, j;
 
-  for ( i = 0; i < num_patterns; i++ ) {
+    for ( i = 0; i < num_patterns; i++ ) {
+        buffer[0] = '\0';
 
-      buffer[0] = '\0';
+        int rounds = (rand_int() % 10) + 2;
+        for ( j = 0; j < rounds; j++ ) {
+            if ( j != 0 )
+                strcat(buffer, "*");
 
-      int rounds = (rand_int() % 10) + 2;
-      for ( j = 0; j < rounds; j++ ) {
-
-          if ( j != 0 )
-              strcat(buffer, "*");
-
-          if ( (rand_int() % 10) == 0 ) {
-              strcat(buffer, random_pattern_word());
+            if ( (rand_int() % 10) == 0 ) {
+                strcat(buffer, random_pattern_word());
             }
-          else {
-              strcat(buffer, random_word());
+            else {
+                strcat(buffer, random_word());
             }
-      }
+        }
 
-      std::string s(buffer);
-      patterns[i] = s;
+        std::string s(buffer);
+        patterns[i] = s;
     }
 
     // Create the queries.
 
-  std::unique_ptr<std::string[]> queries(new std::string[num_queries]);
+    std::unique_ptr<std::string[]> queries(new std::string[num_queries]);
 
-  for ( i = 0; i < num_queries; i++ ) {
+    for ( i = 0; i < num_queries; i++ ) {
+        buffer[0] = '\0';
 
-      buffer[0] = '\0';
+        if ( (rand_int() % 100) <= match_prob ) {
+            // Create a likely match candidate.
+            int rounds = (rand_int() % 5) + 1;
+            for ( j = 0; j < rounds; j++ ) {
+                strcat(buffer, random_pattern_word());
+            }
+        }
 
-      if ( (rand_int() % 100) <= match_prob ) {
-          // Create a likely match candidate.
-          int rounds = (rand_int() % 5) + 1;
-          for ( j = 0; j < rounds; j++ ) {
-              strcat(buffer, random_pattern_word());
-          }
-      }
+        else {
+            // Create a mismatch.
+            int rounds = (rand_int() % 50) + 5;
+            for ( j = 0; j < rounds; j++ ) {
+                buffer[j] = (char)((rand_int() % 26) + 'a');
+            }
 
-      else {
-          // Create a mismatch.
-          int rounds = (rand_int() % 50) + 5;
-          for ( j = 0; j < rounds; j++ ) {
-              buffer[j] = (char)((rand_int() % 26) + 'a');
-          }
+            buffer[rounds] = '\0';
+        }
 
-          buffer[rounds] = '\0';
-      }
+        queries[i] = std::string(strdup(buffer));
+    }
 
-      queries[i] = std::string(strdup(buffer));
-  }
+    if ( ! silent ) {
+        std::cout << "creating paraglob \n";
+    }
+    auto build_start = std::chrono::high_resolution_clock::now();
+    paraglob::Paraglob myGlob;
+    for ( i = 0; i < num_patterns; ++i ) {
+        const auto& p = patterns[i];
+        myGlob.add(p);
+    }
+    myGlob.compile();
+    auto build_finish = std::chrono::high_resolution_clock::now();
+    std::chrono::duration<double> build_time = build_finish - build_start;
 
-  if (!silent) {
-    std::cout << "creating paraglob \n";
-  }
-  auto build_start = std::chrono::high_resolution_clock::now();
-  paraglob::Paraglob myGlob;
-  for ( i = 0; i < num_patterns; ++i ) {
-    const auto& p = patterns[i];
-    myGlob.add(p);
-  }
-  myGlob.compile();
-  auto build_finish = std::chrono::high_resolution_clock::now();
-  std::chrono::duration<double> build_time = build_finish - build_start;
+    auto start = std::chrono::high_resolution_clock::now();
 
-  auto start = std::chrono::high_resolution_clock::now();
+    if ( ! silent ) {
+        std::cout << "making queries \n";
+    }
+    for ( i = 0; i < num_queries; ++i ) {
+        const auto& q = queries[i];
+        myGlob.get(q);
+    }
 
-  if (!silent) {
-    std::cout << "making queries \n";
-  }
-  for ( i = 0; i < num_queries; ++i ) {
-    const auto& q = queries[i];
-    myGlob.get(q);
-  }
+    auto finish = std::chrono::high_resolution_clock::now();
+    std::chrono::duration<double> elapsed = finish - start;
 
-  auto finish = std::chrono::high_resolution_clock::now();
-  std::chrono::duration<double> elapsed = finish - start;
+    if ( ! silent ) {
+        std::cout << "Build time: " << build_time.count() << "s\n";
+        std::cout << "Search time: " << elapsed.count() << " s\n";
+        std::cout << "Queries/second: " << num_queries / elapsed.count() << "\n";
+    }
 
-  if (!silent) {
-    std::cout << "Build time: " << build_time.count() << "s\n";
-    std::cout << "Search time: " << elapsed.count() << " s\n";
-    std::cout << "Queries/second: " << num_queries/elapsed.count() << "\n";
-  }
-
-  return elapsed.count() + build_time.count();
+    return elapsed.count() + build_time.count();
 }
 
 void makeGraphData() {
-  /*
-  prints data to the console for generation of 3d plot
-  of paraglob performance.
-  x axis is number of patterns
-  y axis is number of queries
-  z axis is the time taken to build and run the queries
-  */
-  for(long patterns = 500; patterns <= 10000; patterns += 500) {
-    std::cout << "{ ";
-    for(long queries = 1000; queries <= 20000; queries += 1000) {
-      std::cout << benchmark_n(patterns, queries, 10, true);
-      if (queries != 20000) {
-        std::cout << ", ";
-      }
+    /*
+    prints data to the console for generation of 3d plot
+    of paraglob performance.
+    x axis is number of patterns
+    y axis is number of queries
+    z axis is the time taken to build and run the queries
+    */
+    for ( long patterns = 500; patterns <= 10000; patterns += 500 ) {
+        std::cout << "{ ";
+        for ( long queries = 1000; queries <= 20000; queries += 1000 ) {
+            std::cout << benchmark_n(patterns, queries, 10, true);
+            if ( queries != 20000 ) {
+                std::cout << ", ";
+            }
+        }
+        std::cout << "},\n";
     }
-    std::cout << "},\n";
-  }
 }

--- a/tools/benchmark.cpp
+++ b/tools/benchmark.cpp
@@ -2,8 +2,11 @@
 
 #include "benchmark.h"
 
+#include <iostream>
 #include <memory>
 #include <random>
+
+#include "paraglob/paraglob.h"
 
 std::random_device dev;
 std::mt19937 rng(dev());
@@ -15,12 +18,12 @@ static const char* benchmark_pattern_words[] = {
     "aaaaaa", "bb", "cccccccccccccccc", "ddddd", "eeeeeeeee", "fffffffffffff", "gggg",
 };
 
-const char* random_pattern_word() {
+static const char* random_pattern_word() {
     int idx = rand_int() % (sizeof(benchmark_pattern_words) / sizeof(const char*));
     return benchmark_pattern_words[idx];
 }
 
-const char* random_word() {
+static const char* random_word() {
     static char buffer[1024];
 
     int j;

--- a/tools/benchmark.h
+++ b/tools/benchmark.h
@@ -3,9 +3,9 @@
 #ifndef BENCHMARK_H
 #define BENCHMARK_H
 
-#include <iostream>
-#include <cstring>
 #include <chrono>
+#include <cstring>
+#include <iostream>
 
 #include "paraglob/paraglob.h"
 

--- a/tools/benchmark.h
+++ b/tools/benchmark.h
@@ -1,18 +1,11 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#ifndef BENCHMARK_H
-#define BENCHMARK_H
+#pragma once
 
-#include <chrono>
 #include <cstring>
-#include <iostream>
-
-#include "paraglob/paraglob.h"
 
 /* A set of benchmark functions exercising paraglob with different workloads. */
 double benchmark(char* a, char* b, char* c, bool silent);
 double benchmark_n(long num_patterns, long num_queries, long match_prob, bool silent);
 
 void makeGraphData();
-
-#endif

--- a/tools/driver.cpp
+++ b/tools/driver.cpp
@@ -50,7 +50,7 @@ int main(int argc, char* argv[]) {
         char* a = argv[2];
         char* b = argv[3];
         char* c = argv[4];
-        double elapsed = benchmark(a, b, c, max_time);
+        double elapsed = benchmark(a, b, c, false);
 
         if ( max_time > 0 ) {
             if ( elapsed <= max_time ) {

--- a/tools/driver.cpp
+++ b/tools/driver.cpp
@@ -4,100 +4,97 @@
 A simple driver for testing paraglob's performance and functionality.
 
 Supports the following arguments:
-	-b <a> <b> <c> <time>	-> Benchmark paraglob.  See below.
-	-n <text> <patterns>	-> Print the number of matching patterns in the text.
+    -b <a> <b> <c> <time>	-> Benchmark paraglob.  See below.
+    -n <text> <patterns>	-> Print the number of matching patterns in the text.
 
 Benchmarking:
-	a	-> number of patterns to generate
-	b -> number of queries to perform
-	c -> percentage of generated patterns that match queries
+    a	-> number of patterns to generate
+    b -> number of queries to perform
+    c -> percentage of generated patterns that match queries
 
-	<time> -> optional. If provided, rather than printing detailed results,
-						prints 1 or 0 corresponding to rather or not the benchmark was
-						completed in under <time> seconds
+    <time> -> optional. If provided, rather than printing detailed results,
+                        prints 1 or 0 corresponding to rather or not the benchmark was
+                        completed in under <time> seconds
 
 Note that this script is just for testing and as such if you give it bad
 arguments it will ungracefully break.
 */
 
-#include <iostream>
 #include <cstring>
-#include <vector>
 #include <fstream>
+#include <iostream>
+#include <vector>
 
-#include "paraglob/paraglob.h"
 #include "benchmark.h"
+#include "paraglob/paraglob.h"
 
 int main(int argc, char* argv[]) {
-	double max_time = 0;
+    double max_time = 0;
 
-	if (argc <= 1) {
-		std::cerr << "usage: " << argv[0] << " -n <text> <patterns>\n";
-		std::cerr << "       " <<
-			"Prints the number of patterns that match the text.\n";
-		std::cerr << "       " << argv[0] << " -b <a> <b> <c> <time>\n";
-		std::cerr << "       " <<
-			"Benchmark. a - n patterns. b - n queries. c - % matches.\n";
-		std::cerr << "       " << argv[0] << " -s <patterns>\n";
-		std::cerr << "       " <<
-			"Prints a a paraglob with **patterns** serialization\n";
-		exit(1);
-	}
+    if ( argc <= 1 ) {
+        std::cerr << "usage: " << argv[0] << " -n <text> <patterns>\n";
+        std::cerr << "       " << "Prints the number of patterns that match the text.\n";
+        std::cerr << "       " << argv[0] << " -b <a> <b> <c> <time>\n";
+        std::cerr << "       " << "Benchmark. a - n patterns. b - n queries. c - % matches.\n";
+        std::cerr << "       " << argv[0] << " -s <patterns>\n";
+        std::cerr << "       " << "Prints a a paraglob with **patterns** serialization\n";
+        exit(1);
+    }
 
-	if (strcmp(argv[1], "-b") == 0) {
-		if (argc == 6) {
-			// there is a time argument
-			max_time = atof(argv[5]);
-		}
+    if ( strcmp(argv[1], "-b") == 0 ) {
+        if ( argc == 6 ) {
+            // there is a time argument
+            max_time = atof(argv[5]);
+        }
 
-		char* a = argv[2];
-		char* b = argv[3];
-		char* c = argv[4];
-		double elapsed = benchmark(a, b, c, max_time);
+        char* a = argv[2];
+        char* b = argv[3];
+        char* c = argv[4];
+        double elapsed = benchmark(a, b, c, max_time);
 
-		if (max_time > 0) {
-			if (elapsed <= max_time) {
-				std::cout << "Passed.\n";
-			} else {
-				std::cout << "Failed.\n";
-			}
-		}
-	} else if (strcmp(argv[1], "-n") == 0) {
-		std::vector<std::string> v;
-		for (int i = 3 ; i < argc ; i++) {
-			v.push_back(std::string(argv[i]));
-		}
-		paraglob::Paraglob p(v);
-		std::cout << p.get(std::string(argv[2])).size() << "\n";
-		std::cout << p.str();
-	} else if (strcmp(argv[1], "-s") == 0) {
-		std::vector<std::string> v;
-		for (int i = 3 ; i < argc ; i++) {
-			v.push_back(std::string(argv[i]));
-		}
-		try
-			{
-			paraglob::Paraglob p(v);
-			paraglob::Paraglob sp(p.serialize());
-			if (p == sp)
-				std::cout << "passed" << std::endl;
-			else
-				std::cout << "failed" << std::endl;
-			}
-		catch(const paraglob::overflow_error &e)
-			{
-			std::cerr << e.what() << '\n';
-			}
-	}
-	else if (strcmp(argv[1], "-str") == 0) {
-		std::vector<std::string> v;
-		for (int i = 3 ; i < argc ; i++) {
-			v.push_back(std::string(argv[i]));
-		}
-		paraglob::Paraglob p(v);
-		std::cout << p.str();
-	}
-	else {
-		std::cout << "Unrecognized first param\n";
-	}
+        if ( max_time > 0 ) {
+            if ( elapsed <= max_time ) {
+                std::cout << "Passed.\n";
+            }
+            else {
+                std::cout << "Failed.\n";
+            }
+        }
+    }
+    else if ( strcmp(argv[1], "-n") == 0 ) {
+        std::vector<std::string> v;
+        for ( int i = 3; i < argc; i++ ) {
+            v.push_back(std::string(argv[i]));
+        }
+        paraglob::Paraglob p(v);
+        std::cout << p.get(std::string(argv[2])).size() << "\n";
+        std::cout << p.str();
+    }
+    else if ( strcmp(argv[1], "-s") == 0 ) {
+        std::vector<std::string> v;
+        for ( int i = 3; i < argc; i++ ) {
+            v.push_back(std::string(argv[i]));
+        }
+        try {
+            paraglob::Paraglob p(v);
+            paraglob::Paraglob sp(p.serialize());
+            if ( p == sp )
+                std::cout << "passed" << std::endl;
+            else
+                std::cout << "failed" << std::endl;
+        } catch ( const paraglob::overflow_error& e ) {
+            std::cerr << e.what() << '\n';
+        }
+    }
+    else if ( strcmp(argv[1], "-str") == 0 ) {
+        std::vector<std::string> v;
+        for ( int i = 3; i < argc; i++ ) {
+            v.push_back(std::string(argv[i]));
+        }
+        paraglob::Paraglob p(v);
+        std::cout << p.str();
+    }
+    else {
+        std::cout << "Unrecognized first param\n";
+    }
 }

--- a/tools/driver.cpp
+++ b/tools/driver.cpp
@@ -21,11 +21,11 @@ arguments it will ungracefully break.
 */
 
 #include <cstring>
-#include <fstream>
 #include <iostream>
 #include <vector>
 
 #include "benchmark.h"
+#include "paraglob/exceptions.h"
 #include "paraglob/paraglob.h"
 
 int main(int argc, char* argv[]) {


### PR DESCRIPTION
This brings over part of the configuration from Zeek for pre-commit, including cmake-format and clang-format. It reformats all of the code to match the standard that we use for most of the rest of the Zeek projects. It also includes some general manual code cleanup.