### PR TITLE
Extend maximum paraglob tree size

### DIFF
--- a/include/paraglob/paraglob.h
+++ b/include/paraglob/paraglob.h
@@ -18,13 +18,13 @@ namespace paraglob {
 class Paraglob {
 public:
     /* Create an empty paraglob to fill with add and finalize with compile */
-    Paraglob();
+    Paraglob(size_t max_tree_size = 2048);
 
     /* Initialize a paraglob from a (large) vector of patterns and compile */
-    Paraglob(const std::vector<std::string>& patterns);
+    Paraglob(const std::vector<std::string>& patterns, size_t max_tree_size = 2048);
 
     /* Initialize and compile a paraglob from a serialized one */
-    Paraglob(std::unique_ptr<std::vector<uint8_t>> serialized);
+    Paraglob(std::unique_ptr<std::vector<uint8_t>> serialized, size_t max_tree_size = 2048);
 
     /* Destructor */
     ~Paraglob();

--- a/include/paraglob/paraglob.h
+++ b/include/paraglob/paraglob.h
@@ -60,7 +60,6 @@ private:
     std::unique_ptr<aca_handle> handle;
     std::unordered_map<std::string, paraglob::ParaglobNode> meta_to_node_map;
     std::vector<std::string> meta_words;
-    std::set<std::string> meta_word_set;
 
     /* Patterns with no meta words, ex: '*' & '?' */
     std::vector<std::string> single_wildcards;

--- a/src/paraglob.cpp
+++ b/src/paraglob.cpp
@@ -16,10 +16,10 @@ class aca_handle : public aca {};
 
 using namespace paraglob;
 
-Paraglob::Paraglob() : handle(std::make_unique<aca_handle>()) { aca_init(static_cast<aca*>(handle.get()), 256); }
+Paraglob::Paraglob() : handle(std::make_unique<aca_handle>()) { aca_init(static_cast<aca*>(handle.get()), 2048); }
 
 Paraglob::Paraglob(const std::vector<std::string>& patterns) : handle(std::make_unique<aca_handle>()) {
-    aca_init(static_cast<aca*>(handle.get()), 256);
+    aca_init(static_cast<aca*>(handle.get()), 2048);
 
     for ( const std::string& pattern : patterns ) {
         if ( ! (add(pattern)) ) {

--- a/src/paraglob.cpp
+++ b/src/paraglob.cpp
@@ -16,10 +16,13 @@ class aca_handle : public aca {};
 
 using namespace paraglob;
 
-Paraglob::Paraglob() : handle(std::make_unique<aca_handle>()) { aca_init(static_cast<aca*>(handle.get()), 2048); }
+Paraglob::Paraglob(size_t max_tree_size) : handle(std::make_unique<aca_handle>()) {
+    aca_init(static_cast<aca*>(handle.get()), max_tree_size);
+}
 
-Paraglob::Paraglob(const std::vector<std::string>& patterns) : handle(std::make_unique<aca_handle>()) {
-    aca_init(static_cast<aca*>(handle.get()), 2048);
+Paraglob::Paraglob(const std::vector<std::string>& patterns, size_t max_tree_size)
+    : handle(std::make_unique<aca_handle>()) {
+    aca_init(static_cast<aca*>(handle.get()), max_tree_size);
 
     for ( const std::string& pattern : patterns ) {
         if ( ! (add(pattern)) ) {
@@ -30,8 +33,8 @@ Paraglob::Paraglob(const std::vector<std::string>& patterns) : handle(std::make_
     compile();
 }
 
-Paraglob::Paraglob(std::unique_ptr<std::vector<uint8_t>> serialized)
-    : Paraglob(ParaglobSerializer::unserialize(serialized)) {}
+Paraglob::Paraglob(std::unique_ptr<std::vector<uint8_t>> serialized, size_t max_tree_size)
+    : Paraglob(ParaglobSerializer::unserialize(serialized), max_tree_size) {}
 
 Paraglob::~Paraglob() { aca_destroy(handle.get()); }
 

--- a/src/paraglob.cpp
+++ b/src/paraglob.cpp
@@ -23,6 +23,7 @@ Paraglob::Paraglob(const std::vector<std::string>& patterns) : handle(std::make_
 
     for ( const std::string& pattern : patterns ) {
         if ( ! (add(pattern)) ) {
+            aca_destroy(handle.get());
             throw paraglob::add_error("Failed to add pattern: " + pattern);
         }
     }
@@ -37,8 +38,10 @@ Paraglob::~Paraglob() { aca_destroy(handle.get()); }
 bool Paraglob::add(const std::string& pattern) {
     for ( const std::string& meta_word : get_meta_words(pattern) ) {
         if ( ! meta_to_node_map.contains(meta_word) ) {
-            aca_add(static_cast<aca*>(handle.get()), const_cast<char*>(meta_word.c_str()),
-                    static_cast<int>(meta_word.size()));
+            if ( aca_add(static_cast<aca*>(handle.get()), const_cast<char*>(meta_word.c_str()),
+                         static_cast<int>(meta_word.size())) == -1 )
+                return false;
+
             meta_words.push_back(meta_word);
             // Build the new paraglobNode in place.
             meta_to_node_map.emplace(std::piecewise_construct, std::forward_as_tuple(meta_word),

--- a/src/paraglob.cpp
+++ b/src/paraglob.cpp
@@ -82,8 +82,8 @@ std::vector<std::string> Paraglob::get(const std::string& text) {
         patterns.insert(patterns.end(), single_wildcards.begin(), single_wildcards.end());
 
     // Remove duplicates
-    std::ranges::sort(patterns);
-    patterns.erase(std::unique(patterns.begin(), patterns.end()), patterns.end());
+    auto [first, last] = std::ranges::unique(patterns);
+    patterns.erase(first, last);
     return patterns;
 }
 
@@ -116,7 +116,8 @@ std::vector<std::string> Paraglob::get_meta_words(const std::string& pattern) {
     // Split the pattern by brackets
     for ( const std::string& word : split_on_brackets(pattern) ) {
         // Parse each bracket section
-        std::size_t prev = 0, pos;
+        size_t prev = 0;
+        size_t pos;
 
         while ( (pos = word.find_first_of("*?", prev)) != std::string::npos ) {
             if ( pos > prev ) {
@@ -145,8 +146,8 @@ std::vector<std::string> Paraglob::get_patterns() const {
         patterns.insert(patterns.end(), single_wildcards.begin(), single_wildcards.end());
 
     // Remove the duplicate patterns. Duplicates don't effect the state.
-    std::sort(patterns.begin(), patterns.end());
-    patterns.erase(unique(patterns.begin(), patterns.end()), patterns.end());
+    auto [first, last] = std::ranges::unique(patterns);
+    patterns.erase(first, last);
 
     return patterns;
 }
@@ -178,7 +179,7 @@ std::string Paraglob::str() const {
             std::for_each(v.rbegin(), v.rbegin() + 3, add_string);
         }
         else {
-            std::for_each(v.begin(), v.end(), add_string);
+            std::ranges::for_each(v, add_string);
         }
         add_string("]\n");
     };


### PR DESCRIPTION
This PR extends the maximum size a paraglob tree can be before returning errors. This really feels like an arbitrary number, but we've already seen one case where someone hit the current limitation. Extend it by about 8x to hopefully cut off any cases of someone hitting it in the future. It also fixes the error handling to actually return an error if we hit the size limit. Lastly, it makes it configurable when constructing the paraglob object so that callers can pass a limit if they're finding the default too small.

There's a bit of code cleanup that emacs/flycheck was complaining about as well.

Part of fixing https://github.com/zeek/zeek/issues/5151.